### PR TITLE
Switch to using $WPT_URL for the crawl links extraction

### DIFF
--- a/dist/crawl_links.js
+++ b/dist/crawl_links.js
@@ -26,7 +26,7 @@ const viewport = {
 };
 const getLinks = function(visibleOnly){
     let links = {};
-    const documentOrigin = window.location.href;
+    const documentOrigin = $WPT_URL;
     const elements = document.links;
     for (let e of elements) {
         try {


### PR DESCRIPTION
The agents now support a string substitution where $WPT_URL will be replaced by the last URL that WPT navigated to as part of the test. This is needed to make sure that the links extracted are of the same origin as the page we initially navigated to, not necessarily wherever redirects took us.