### PR TITLE
Add Markup 2022 custom metrics

### DIFF
--- a/dist/markup.js
+++ b/dist/markup.js
@@ -632,7 +632,13 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
       const SPECIAL_SCHEMES = new Set(['ftp:', 'file:', 'http:', 'https:', 'ws:', 'wss:']);
 
       const hrefs_without_special_scheme = Array.from(document.querySelectorAll('a[href]')).filter(a => {
-        const url = new URL(a.href);
+        let url;
+        try {
+          url = new URL(a.href);
+        } catch (e) {
+          return false;
+        }
+        
         return !SPECIAL_SCHEMES.has(url.protocol);
       }).map(a => a.href);
       

--- a/dist/markup.js
+++ b/dist/markup.js
@@ -638,10 +638,10 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
         } catch (e) {
           return false;
         }
-        
+
         return !SPECIAL_SCHEMES.has(url.protocol);
       }).map(a => a.href);
-      
+
       return {
         hrefs_without_special_scheme
       };

--- a/dist/markup.js
+++ b/dist/markup.js
@@ -1,10 +1,6 @@
 //[markup]
 // Uncomment the previous line for testing on webpagetest.org
 
-// Instructions for adding a new custom metric are in almanac.js.
-
-// output size ~ 1.5k to 2k
-
 var _logs = [];
 // saves the error details in the results log property.
 // returns the same error object so that it can be also used as the return value for a property.

--- a/dist/markup.js
+++ b/dist/markup.js
@@ -625,6 +625,20 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
       catch(e) {
         return logError("app", e);
       }
+    })(),
+
+    'anchors': (() => {
+      // https://url.spec.whatwg.org/#special-scheme
+      const SPECIAL_SCHEMES = new Set(['ftp:', 'file:', 'http:', 'https:', 'ws:', 'wss:']);
+
+      const hrefs_without_special_scheme = Array.from(document.querySelectorAll('a[href]')).filter(a => {
+        const url = new URL(a.href);
+        return !SPECIAL_SCHEMES.has(url.protocol);
+      }).map(a => a.href);
+      
+      return {
+        hrefs_without_special_scheme
+      };
     })()
   };
 }


### PR DESCRIPTION
Fixes #17 

Tests:

- [`anchors.hrefs_without_special_scheme`](https://webpagetest.httparchive.org/result/220523_4H_8/1/details/#waterfall_view_step1) (https://codepen.io/rviscomi/pen/YzerzNX)
- [Custom elements](https://webpagetest.httparchive.org/result/220523_1T_G/1/details/#waterfall_view_step1) (https://codepen.io/rviscomi/pen/MWQmdzq)
- [Custom elements](https://webpagetest.httparchive.org/result/220524_WE_5/1/details/#waterfall_view_step1) (https://dictionary.cambridge.org/plus/)