### PR TITLE
Performance 2022 custom metrics

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -93,6 +93,7 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
     let rawLcpElement = null;
     const isLcpExternalResource = lcpUrl != '';
     if (isLcpExternalResource) {
+        // Check if LCP resource reference is in the raw HTML (as opposed to being injected later by JS)
         rawLcpElement = Array.from(rawDoc.querySelectorAll('picture source, img')).find(i => {
             let src = i.src;
             if (i.nodeName == 'SOURCE') {
@@ -102,7 +103,7 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
             return src == lcpUrl;
         });
         isLcpDiscoverable = !!rawLcpElement;
-        isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
+        isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('link')).find(link => {
             return link.rel == 'preload' && link.href == lcpUrl;
         });
         responseObject = response_bodies.find(r => {

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -55,8 +55,13 @@ return Promise.all([getLcpElement()]).then(lcp_elem_stats => {
     let responseObject = null;
     const isLcpExternalResource = lcp_elem_stats[0].url != '';
     if (isLcpExternalResource) {
-        isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('img')).find(img => {
-            return img.src == lcp_elem_stats[0].url;
+        isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('picture source, img')).find(img => {
+            let lcpUrl = img.src;
+            if (img.tagName == 'SOURCE') {
+                lcpUrl = img.srcset;
+            }
+
+            return lcpUrl == lcp_elem_stats[0].url;
         });
         isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
             return link.rel == 'preload' && link.href == lcp_elem_stats[0].url;

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -3,13 +3,13 @@
 const response_bodies = $WPT_BODIES;
 
 function getRawHtmlDocument() {
-    let _rawHtml;
-    if (_wptBodies.length > 0) {
-        _rawHtml = _wptBodies[0].response_body;
+    let rawHtml;
+    if (response_bodies.length > 0) {
+        rawHtml = response_bodies[0].response_body;
     }
 
     rawHtmlDocument = document.implementation.createHTMLDocument("New Document");
-    rawHtmlDocument.documentElement.innerHTML = html;
+    rawHtmlDocument.documentElement.innerHTML = rawHtml;
 
     return rawHtmlDocument;
 }
@@ -51,14 +51,22 @@ function getWebVitalsJS() {
 return Promise.all([getLcpElement()]).then(lcp_elem_stats => {
     const rawDoc = getRawHtmlDocument();
     const isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('img')).find(img => {
-        return img.src == lcp_elem_stats.url;
+        return img.src == lcp_elem_stats[0].url;
     });
     const isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
-        return link.rel == 'preload' && link.href == lcp_elem_stats.url;
+        return link.rel == 'preload' && link.href == lcp_elem_stats[0].url;
     });
+    const responseObject = response_bodies.find(r => {
+        return r.url == lcp_elem_stats[0].url;
+    });
+    if (responseObject) {
+        // Don't write the response body to custom metrics.
+        responseObject.response_body = undefined;
+    }
 
     return {
         lcp_elem_stats,
+        lcp_resource: responseObject,
         is_lcp_discoverable: isLcpDiscoverable,
         is_lcp_preloaded: isLcpPreloaded,
         web_vitals_js: getWebVitalsJS()

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -2,6 +2,18 @@
 
 const response_bodies = $WPT_BODIES;
 
+function getRawHtmlDocument() {
+    let _rawHtml;
+    if (_wptBodies.length > 0) {
+        _rawHtml = _wptBodies[0].response_body;
+    }
+
+    rawHtmlDocument = document.implementation.createHTMLDocument("New Document");
+    rawHtmlDocument.documentElement.innerHTML = html;
+
+    return rawHtmlDocument;
+}
+
 function getLcpElement() {
     return new Promise((resolve) => {
         new PerformanceObserver((entryList) => {
@@ -37,8 +49,18 @@ function getWebVitalsJS() {
 }
 
 return Promise.all([getLcpElement()]).then(lcp_elem_stats => {
+    const rawDoc = getRawHtmlDocument();
+    const isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('img')).find(img => {
+        return img.src == lcp_elem_stats.url;
+    });
+    const isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
+        return link.rel == 'preload' && link.href == lcp_elem_stats.url;
+    });
+
     return {
         lcp_elem_stats,
+        is_lcp_discoverable: isLcpDiscoverable,
+        is_lcp_preloaded: isLcpPreloaded,
         web_vitals_js: getWebVitalsJS()
     };
 });

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -61,7 +61,7 @@ return Promise.all([getLcpElement()]).then(lcp_elem_stats => {
         isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
             return link.rel == 'preload' && link.href == lcp_elem_stats[0].url;
         });
-        const responseObject = response_bodies.find(r => {
+        responseObject = response_bodies.find(r => {
             return r.url == lcp_elem_stats[0].url;
         });
         if (responseObject) {

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -87,7 +87,7 @@ function getWebVitalsJS() {
 return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
     const lcpUrl = lcp_elem_stats.url;
     const rawDoc = getRawHtmlDocument();
-    let isLcpDiscoverable = null;
+    let isLcpStaticallyDiscoverable = null;
     let isLcpPreloaded = null;
     let responseObject = null;
     let rawLcpElement = null;
@@ -102,7 +102,7 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
 
             return src == lcpUrl;
         });
-        isLcpDiscoverable = !!rawLcpElement;
+        isLcpStaticallyDiscoverable = !!rawLcpElement;
         isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('link')).find(link => {
             return link.rel == 'preload' && link.href == lcpUrl;
         });
@@ -119,7 +119,7 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
         lcp_elem_stats,
         raw_lcp_element: summarizeLcpElement(rawLcpElement),
         lcp_resource: responseObject,
-        is_lcp_discoverable: isLcpDiscoverable,
+        is_lcp_statically_discoverable: isLcpStaticallyDiscoverable,
         is_lcp_preloaded: isLcpPreloaded,
         web_vitals_js: getWebVitalsJS()
     };

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -49,25 +49,22 @@ function getWebVitalsJS() {
 }
 
 return Promise.all([getLcpElement()]).then(lcp_elem_stats => {
+    const lcpUrl = lcp_elem_stats[0].url;
     const rawDoc = getRawHtmlDocument();
     let isLcpDiscoverable = null;
     let isLcpPreloaded = null;
     let responseObject = null;
-    const isLcpExternalResource = lcp_elem_stats[0].url != '';
+    const isLcpExternalResource = lcpUrl != '';
     if (isLcpExternalResource) {
-        isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('picture source, img')).find(img => {
-            let lcpUrl = img.src;
-            if (img.tagName == 'SOURCE') {
-                lcpUrl = img.srcset;
-            }
-
-            return lcpUrl == lcp_elem_stats[0].url;
+        isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('picture source, img')).find(i => {
+            const src = i.src || i.srcset;
+            return src == lcpUrl;
         });
         isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
-            return link.rel == 'preload' && link.href == lcp_elem_stats[0].url;
+            return link.rel == 'preload' && link.href == lcpUrl;
         });
         responseObject = response_bodies.find(r => {
-            return r.url == lcp_elem_stats[0].url;
+            return r.url == lcpUrl;
         });
         if (responseObject) {
             // Don't write the response body to custom metrics.

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -50,18 +50,24 @@ function getWebVitalsJS() {
 
 return Promise.all([getLcpElement()]).then(lcp_elem_stats => {
     const rawDoc = getRawHtmlDocument();
-    const isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('img')).find(img => {
-        return img.src == lcp_elem_stats[0].url;
-    });
-    const isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
-        return link.rel == 'preload' && link.href == lcp_elem_stats[0].url;
-    });
-    const responseObject = response_bodies.find(r => {
-        return r.url == lcp_elem_stats[0].url;
-    });
-    if (responseObject) {
-        // Don't write the response body to custom metrics.
-        responseObject.response_body = undefined;
+    let isLcpDiscoverable = null;
+    let isLcpPreloaded = null;
+    let responseObject = null;
+    const isLcpExternalResource = lcp_elem_stats[0].url != '';
+    if (isLcpExternalResource) {
+        isLcpDiscoverable = !!Array.from(rawDoc.querySelectorAll('img')).find(img => {
+            return img.src == lcp_elem_stats[0].url;
+        });
+        isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('head link')).find(link => {
+            return link.rel == 'preload' && link.href == lcp_elem_stats[0].url;
+        });
+        const responseObject = response_bodies.find(r => {
+            return r.url == lcp_elem_stats[0].url;
+        });
+        if (responseObject) {
+            // Don't write the response body to custom metrics.
+            responseObject.response_body = undefined;
+        }
     }
 
     return {


### PR DESCRIPTION
Progress on #16 

Additional metadata about the LCP element:

- `is_lcp_discoverable`: boolean whether it was discoverable in the raw HTML
- `is_lcp_preloaded`: boolean whether it was preloaded
- `boundingClientRect`: dimensions and position of the rendered element
- `naturalHeight`, `naturalWidth`: intrinsic image dimensions
- `lcp_resource`: full WPT response metadata
- `raw_lcp_element`: node name and attributes of the element in the raw HTML
- `styles`: allowlist of computed style prop/value pairs, set to `background-image` for now

Everything is applicable to images. The `boundingClientRect` will also be available for text-based LCP elements.

## Tests

- Image preloaded image, not discoverable
  - URL: https://rviscomi.github.io/demos/lcp_preloaded.html
  - Results: https://webpagetest.httparchive.org/result/220526_QT_12/1/details/#waterfall_view_step1
- Image not preloaded, discoverable
  - URL: https://www.nytimes.com/
  - Results: https://webpagetest.httparchive.org/result/220526_ND_10/1/details/#waterfall_view_step1
- Sourceset image not preloaded, discoverable
  - URL: https://almanac.httparchive.org/en/2021/css
  - Results: https://webpagetest.httparchive.org/result/220526_EE_14/1/details/#waterfall_view_step1
- Background image not preloaded, not discoverable?
  - URL: https://codepen.io/rviscomi/pen/wvyPQoM
  - Results: https://webpagetest.httparchive.org/result/220526_H2_15/1/details/#waterfall_view_step1
- Not an image
  - URL: https://www.example.com/
  - Results: https://webpagetest.httparchive.org/result/220526_V1_11/1/details/#waterfall_view_step1