### PR TITLE
Added custom metric for Webpack and ParcelJS

### DIFF
--- a/dist/javascript.js
+++ b/dist/javascript.js
@@ -91,6 +91,14 @@ return JSON.stringify({
         };
 
         return noscript_data;
-    })()
+    })(),
 
+    bundler: (() => {
+        const bundler = {
+            webpack: !(typeof webpackJsonp === "undefined" && typeof webpackChunk === "undefined"),
+            parcel: !(typeof parcelRequire === "undefined")
+        }
+
+        return Object.entries(bundler).filter(n => n[1]).map(n => n[0]);
+    })()
 });


### PR DESCRIPTION
Added custom metric to return array of known bundlers in use on a page.

**Webpack**
- https://webpagetest.httparchive.org/result/220529_JG_E/1/details/#waterfall_view_step1
- https://webpagetest.httparchive.org/result/220529_RD_C/1/details/#waterfall_view_step1

javascript_new|{"bundler":["webpack"]}
--|--


**Parcel**
- https://webpagetest.httparchive.org/result/220529_SW_J/1/details/#waterfall_view_step1

javascript_new|{"bundler":["parcel"]}
--|--


**None**
- https://webpagetest.httparchive.org/result/220529_FY_F/1/details/#waterfall_view_step1

javascript_new|{"bundler":[]}
--|--

Note that this implementation is built on [wappalyzer](https://github.com/wappalyzer/wappalyzer)'s implementation and is only able to recognize Webpack and Parcel.