### PR TITLE
Fix LCP metrics

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -271,7 +271,6 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
 
             return src == lcpUrl;
         });
-        isLcpStaticallyDiscoverable = !!rawLcpElement;
         isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('link')).find(link => {
             if (link.rel != 'preload') {
                 return false;
@@ -281,9 +280,10 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
             if (link.hasAttribute('imagesrcset')) {
                 src = splitSrcSet(link.imagesrcset, location.href).find(src => src == lcpUrl);
             }
-            
+
             return src == lcpUrl;
         });
+        isLcpStaticallyDiscoverable = !!rawLcpElement || !!isLcpPreloaded;
         responseObject = response_bodies.find(r => {
             return r.url == lcpUrl;
         });

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -243,7 +243,7 @@ function splitSrcSet(srcset) {
     // "img.jpg 100w, img2.jpg 300w"
     return srcset.split(',').map(srcDesc => {
         // "img.jpg 100w", " img2.jpg 300w"
-        const src = srcDesc.trim().split(' ')[0];
+        const src = srcDesc.trim().split(/\s+/)[0];
         return new URL(src, location.href).href;
     });
 }
@@ -255,7 +255,7 @@ function parseLinkHeader(link) {
 
     const srcPattern = /<([^>]+)>/;
     const paramPattern = /([^=]+)=['"]?([^'"]+)['"]?/;
-    return Object.fromEntries(link.split(',').map(l => {
+    return Object.fromEntries(link.split(/[,\n]/).map(l => {
         let [src, ...params] = l.split(';');
 
         if (!srcPattern.test(src)) {

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -300,7 +300,7 @@ function getLcpPreloadInfo(rawDoc, lcpUrl) {
     if (!linkHeaderString) {
         return lcpPreload;
     }
-    
+
     const directives = parseLinkHeader(linkHeaderString);
     if (!(lcpUrl in directives)) {
         return lcpPreload;
@@ -362,7 +362,7 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
         rawLcpElement = getRawLcpElement(rawDoc, lcpUrl);
         lcpPreload = getLcpPreloadInfo(rawDoc, lcpUrl);
         responseObject = getLcpResponseObject(lcpUrl);
-        
+
         isLcpPreloaded = 'header_directives' in lcpPreload || 'tag' in lcpPreload;
         isLcpStaticallyDiscoverable = !!rawLcpElement || isLcpPreloaded;
     }

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -273,7 +273,16 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
         });
         isLcpStaticallyDiscoverable = !!rawLcpElement;
         isLcpPreloaded = !!Array.from(rawDoc.querySelectorAll('link')).find(link => {
-            return link.rel == 'preload' && link.href == lcpUrl;
+            if (link.rel != 'preload') {
+                return false;
+            }
+
+            let src = link.href;
+            if (link.hasAttribute('imagesrcset')) {
+                src = splitSrcSet(link.imagesrcset, location.href).find(src => src == lcpUrl);
+            }
+            
+            return src == lcpUrl;
         });
         responseObject = response_bodies.find(r => {
             return r.url == lcpUrl;


### PR DESCRIPTION
Fixes #45 

- [x] Iterate over multiple `srcset` values
- [x] Handle `img[srcset]` cases
- [x] Include preload in discoverability check
- [x] Handle `srcset` in preload cases
- [x] Include HTTP preloads in preload check