### PR TITLE
Update doctype.js

### DIFF
--- a/dist/doctype.js
+++ b/dist/doctype.js
@@ -12,4 +12,4 @@ if ( dt ) {
     sDoctype += " " + dt.internalSubset;
   }
 }
-return sDoctype.replace(/[\x00-\x1F\x80-\xFF]/g, "");
+return sDoctype.replace(/[\x00-\x1F\x80-\xFF]/g, "").toString();


### PR DESCRIPTION
Fixes an edge case where we get a weird `String` object in the [results](https://webpagetest.httparchive.org/result/220801_Dx1J1_BSM7Z/1/details/#waterfall_view_step1) (see the `doctype` custom metric in the WPT UI):

```
["h","t","m","l"," ","-","\/","\/","W","3","C","\/","\/","D","T","D"," ","H","T","M","L"," ","4",".","0","1"," ","T","r","a","n","s","i","t","i","o","n","a","l","\/","\/","E","N"," ","h","t","t","p",":","\/","\/","w","w","w",".","w","3",".","o","r","g","\/","T","R","\/","h","t","m","l","4","\/","l","o","o","s","e",".","d","t","d"]
```

And here's how it looks in BQ after JSON stringification:

```
{"0": "h", "1": "t", "2": "m", "3": "l", "4": " ", "5": "-", "6": "/", "7": "/", "8": "W", "9": "3", "10": "C", "11": "/", "12": "/", "13": "D", "14": "T", "15": "D", "16": " ", "17": "H", "18": "T", "19": "M", "20": "L", "21": " ", "22": "4", "23": ".", "24": "0", "25": "1", "26": " ", "27": "T", "28": "r", "29": "a", "30": "n", "31": "s", "32": "i", "33": "t", "34": "i", "35": "o", "36": "n", "37": "a", "38": "l", "39": "/", "40": "/", "41": "E", "42": "N", "43": " ", "44": "h", "45": "t", "46": "t", "47": "p", "48": ":", "49": "/", "50": "/", "51": "w", "52": "w", "53": "w", "54": ".", "55": "w", "56": "3", "57": ".", "58": "o", "59": "r", "60": "g", "61": "/", "62": "T", "63": "R", "64": "/", "65": "h", "66": "t", "67": "m", "68": "l", "69": "4", "70": "/", "71": "l", "72": "o", "73": "o", "74": "s", "75": "e", "76": ".", "77": "d", "78": "t", "79": "d"}
```