### PR TITLE
Report on textarea elements in input_elements custom metric

### DIFF
--- a/dist/almanac.js
+++ b/dist/almanac.js
@@ -398,7 +398,7 @@ return JSON.stringify({
   })(),
   // Parse <input> elements
   'input_elements': (() => {
-    var nodes = document.querySelectorAll('input, select');
+    var nodes = document.querySelectorAll('input, select, textarea');
     var inputNodes = parseNodes(nodes , {
       include_only_prop_list: [
         /^aria-.+$/,


### PR DESCRIPTION
This is a custom metric we were considering using for an accessibility chapter query, but didn’t get to it in the end. The data here would have been more valuable if it included `textarea` elements, which support very similar attributes to `input`.

Note textarea is already accounted for elsewhere, for example when deciding what elements to have "input elt only" logic: https://github.com/HTTPArchive/custom-metrics/blob/4c6bc0493b1b51dc021d6dcf7471b80224dc9228/dist/almanac.js#L62.

---

Changing this would impact two existing queries I believe:

- https://github.com/HTTPArchive/almanac.httparchive.org/blob/3cae5692c12a421d3c9df2571451b5d5f3996a78/sql/2022/mobile-web/popular_mobile_input_types.sql
- https://github.com/HTTPArchive/almanac.httparchive.org/blob/3cae5692c12a421d3c9df2571451b5d5f3996a78/sql/2022/mobile-web/usage_of_advanced_input_types.sql

There are other queries using this data, though they tend to only look for `<input>` fields and don’t seem to cover `<select>`. I would expect the addition of `<textarea>` data to not be _that big_ of a difference for existing queries, though it would alter what elements are reported, so might or might not be appropriate depending on the almanac’s policy on reproducibility / YoY comparisons.