### PR TITLE
Added null-check to body when checking JavaScript sourcemaps

### DIFF
--- a/dist/javascript.js
+++ b/dist/javascript.js
@@ -39,7 +39,7 @@ let getSourceMaps = (async () => {
   let sourcemapURLs = scripts
     .map((n) => {
       if (n) {
-        let url = n.body.match(sourcemapRegex)?.[1];
+        let url = n.body?.match(sourcemapRegex)?.[1];
 
         if (url) {
           // Source map URL is relative to stylesheet URL


### PR DESCRIPTION
When the script response does not include a body, for example in the case of a 301 redirect, the custom metric is throwing an unhandled exception and returning `null`.

**Test**
See custom metric `__debug_javascript` on the following URL: https://webpagetest.httparchive.org/result/220928_FZ_D/1/details/#waterfall_view_step1

The test includes a 301 redirect for the script file https://fast.smarketer.de/api/js/fast.js .

**Actual**

Currently this was returning `null`. See the custom metric `__debug_javascript` on the following URL which uses the custom metric prior to the fix: https://webpagetest.httparchive.org/result/220928_70_E/1/details/#waterfall_view_step1

Closes #51 .