### PR TITLE
Support SVG image LCP

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -324,8 +324,7 @@ function getRawLcpElement(rawDoc, lcpUrl) {
         let src = i.src;
         if (i.hasAttribute('srcset')) {
             src = splitSrcSet(i.srcset).find(src => src == lcpUrl);
-        }
-        if (i.hasAttribute('href')) {
+        } else if (i.hasAttribute('href')) {
             src = i.getAttribute('href');
         }
 

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -320,10 +320,13 @@ function getLcpPreloadInfo(rawDoc, lcpUrl) {
 }
 
 function getRawLcpElement(rawDoc, lcpUrl) {
-    const rawLcpElement = Array.from(rawDoc.querySelectorAll('picture source, img')).find(i => {
+    const rawLcpElement = Array.from(rawDoc.querySelectorAll('picture source, img, svg image')).find(i => {
         let src = i.src;
         if (i.hasAttribute('srcset')) {
             src = splitSrcSet(i.srcset).find(src => src == lcpUrl);
+        }
+        if (i.hasAttribute('href')) {
+            src = i.getAttribute('href');
         }
 
         return src == lcpUrl;


### PR DESCRIPTION
This fixes "is statically discoverable" for image-in-SVG LCP

https://webpagetest.httparchive.org/result/221028_5D_2/1/details/

```json
{
    "nodeName": "image",
    "attributes": [
        {
            "name": "href",
            "value": "https://placekitten.com/g/200/300"
        }
    ]
}
```