### PR TITLE
Implement custom metrics to count stylesheets that are within vs after the `<head>` tag

### DIFF
--- a/dist/css.js
+++ b/dist/css.js
@@ -14,12 +14,12 @@ function countInlineCssInHead() {
   return document.querySelectorAll( 'head style' ).length;
 }
 
-function countExternalCssAfterHead() {
-  return document.querySelectorAll( 'link[rel="stylesheet"]' ).length - countExternalCssInHead();
+function countExternalCssInBody() {
+  return document.querySelectorAll( 'body link[rel="stylesheet"]' ).length;
 }
 
-function countInlineCssAfterHead() {
-  return document.querySelectorAll( 'style' ).length - countInlineCssInHead();
+function countInlineCssInBody() {
+  return document.querySelectorAll( 'body style' ).length;
 }
 
 return JSON.stringify({
@@ -72,7 +72,7 @@ return JSON.stringify({
     ).length > 0,
 
   externalCssInHead: countExternalCssInHead(),
-  externalCssAfterHead: countExternalCssAfterHead(),
+  externalCssInBody: countExternalCssInBody(),
   inlineCssInHead: countInlineCssInHead(),
-  inlineCssAfterHead: countInlineCssAfterHead(),
+  inlineCssInBody: countInlineCssInBody(),
 });

--- a/dist/css.js
+++ b/dist/css.js
@@ -6,6 +6,22 @@ const PREFERS_COLOR_SCHEME_REGEXP =
 
 const bodies = $WPT_BODIES;
 
+function countExternalCssInHead() {
+  return document.querySelectorAll( 'head link[rel="stylesheet"]' ).length;
+}
+
+function countInlineCssInHead() {
+  return document.querySelectorAll( 'head style' ).length;
+}
+
+function countExternalCssAfterHead() {
+  return document.querySelectorAll( 'link[rel="stylesheet"]' ).length - countExternalCssInHead();
+}
+
+function countInlineCssAfterHead() {
+  return document.querySelectorAll( 'style' ).length - countInlineCssInHead();
+}
+
 return JSON.stringify({
   css_in_js: (() => {
     const CssInJsMap = {
@@ -54,4 +70,9 @@ return JSON.stringify({
     document.querySelectorAll(
       'link[rel="stylesheet"][media*="prefers-color-scheme"]',
     ).length > 0,
+
+  externalCssInHead: countExternalCssInHead(),
+  externalCssAfterHead: countExternalCssAfterHead(),
+  inlineCssInHead: countInlineCssInHead(),
+  inlineCssAfterHead: countInlineCssAfterHead(),
 });


### PR DESCRIPTION
We would like to get a better idea on how often stylesheets are used in `<head>` vs in `<body>`, and we also would like to be able to assess how common certain combinations are.

For example, we could assume (without 100% reliability) that sites that inline critical CSS have the following:
* no external CSS in `<head>`
* at least 1 inline CSS in `<head>`
* at least 1 external CSS in `<body>`

The custom metrics here should allow us to query for that.