### PR TITLE
add custom metrics for Aurora

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -6,12 +6,12 @@ function isAngularImageDirUser() {
   return !!document.querySelector('img[ng-img]');
 }
 
-// Detects count of NgOptimizedImage instances with a priority attr 
+// Detects count of NgOptimizedImage instances with a priority attr
 function getAngularImagePriorityCount() {
     return document.querySelectorAll('img[ng-img][priority]').length;
 }
 
 return {
     ng_img_user: isAngularImageDirUser(),
-    ng_priority_img_count: getAngularImagePriorityCount()
+    ng_priority_img_count: getAngularImagePriorityCount()<<<<<<< HEAD:dist/aurora_apis.js
 };

--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -13,5 +13,5 @@ function getAngularImagePriorityCount() {
 
 return {
     ng_img_user: isAngularImageDirUser(),
-    ng_priority_img_count: getAngularImagePriorityCount()<<<<<<< HEAD:dist/aurora_apis.js
+    ng_priority_img_count: getAngularImagePriorityCount()
 };

--- a/dist/aurora_apis.js
+++ b/dist/aurora_apis.js
@@ -11,7 +11,7 @@ function getAngularImagePriorityCount() {
     return document.querySelectorAll('img[ng-img][priority]').length;
 }
 
-return JSON.stringify({
+return {
     ng_img_user: isAngularImageDirUser(),
     ng_priority_img_count: getAngularImagePriorityCount()
-});
+};

--- a/dist/aurora_apis.js
+++ b/dist/aurora_apis.js
@@ -1,0 +1,17 @@
+//[aurora]
+// Uncomment the previous line for testing on webpagetest.org
+
+// Detects if NgOptimizedImage is in use on the page
+function isAngularImageDirUser() {
+  return !!document.querySelector('img[ng-img]');
+}
+
+// Detects count of NgOptimizedImage instances with a priority attr 
+function getAngularImagePriorityCount() {
+    return document.querySelectorAll('img[ng-img][priority]').length;
+}
+
+return JSON.stringify({
+    ng_img_user: isAngularImageDirUser(),
+    ng_priority_img_count: getAngularImagePriorityCount()
+});


### PR DESCRIPTION
This commit adds a custom metric for detecting
when the Angular image directive is used and
whether it is marked as "priority". This was
previously difficult to detect using HTTP
Archive because most Angular apps are client-side
rendered, so the output would not be available
in the normal response body table. Closes #59.

WPT test run: https://www.webpagetest.org/result/230119_AiDc4H_H6K/2/details/