### PR TITLE
Better handle redirected pages

### DIFF
--- a/dist/crawl_links.js
+++ b/dist/crawl_links.js
@@ -41,6 +41,7 @@ const getLinks = function(visibleOnly){
             if (rect.width > 1 && rect.height > 1 && (is_visible || !visibleOnly) && e) {
                 const url = e.href;
                 const baseUrl = url.split('#')[0]
+                // Link is not the current page.
                 if (baseUrl != testUrl && baseUrl != currentUrl) {
                     if (sameOrigin(url, testUrl) || sameOrigin(url, currentUrl)) {
                         let size = rect.width * rect.height;

--- a/dist/crawl_links.js
+++ b/dist/crawl_links.js
@@ -37,6 +37,7 @@ const getLinks = function(visibleOnly){
                                 style.visibility !== 'hidden' &&
                                 style.display !== 'none' &&
                                 intersectRect(rect, viewport);
+            // Link is user-visible.
             if (rect.width > 1 && rect.height > 1 && (is_visible || !visibleOnly) && e) {
                 const url = e.href;
                 const baseUrl = url.split('#')[0]

--- a/dist/crawl_links.js
+++ b/dist/crawl_links.js
@@ -39,10 +39,9 @@ const getLinks = function(visibleOnly){
                                 intersectRect(rect, viewport);
             // Link is user-visible.
             if (rect.width > 1 && rect.height > 1 && (is_visible || !visibleOnly) && e) {
-                const url = e.href;
-                const baseUrl = url.split('#')[0]
+                const url = e.href.split('#')[0];
                 // Link is not the current page.
-                if (baseUrl != testUrl && baseUrl != currentUrl) {
+                if (url != testUrl && url != currentUrl) {
                     // Link is to the same origin as the current page.
                     if (sameOrigin(url, testUrl) || sameOrigin(url, currentUrl)) {
                         let size = rect.width * rect.height;

--- a/dist/crawl_links.js
+++ b/dist/crawl_links.js
@@ -43,6 +43,7 @@ const getLinks = function(visibleOnly){
                 const baseUrl = url.split('#')[0]
                 // Link is not the current page.
                 if (baseUrl != testUrl && baseUrl != currentUrl) {
+                    // Link is to the same origin as the current page.
                     if (sameOrigin(url, testUrl) || sameOrigin(url, currentUrl)) {
                         let size = rect.width * rect.height;
                         if (links[url] === undefined) {

--- a/dist/crawl_links.js
+++ b/dist/crawl_links.js
@@ -26,7 +26,8 @@ const viewport = {
 };
 const getLinks = function(visibleOnly){
     let links = {};
-    const documentOrigin = $WPT_TEST_URL;
+    const testUrl = $WPT_TEST_URL;
+    const currentUrl = document.location.href.split('#')[0];
     const elements = document.links;
     for (let e of elements) {
         try {
@@ -36,13 +37,17 @@ const getLinks = function(visibleOnly){
                                 style.visibility !== 'hidden' &&
                                 style.display !== 'none' &&
                                 intersectRect(rect, viewport);
-            if (rect.width > 1 && rect.height > 1 && (is_visible || !visibleOnly) ) {
-                if (e && e.href.split('#')[0] != documentOrigin && sameOrigin(e.href, documentOrigin)) {
-                    let size = rect.width * rect.height;
-                    if (links[e.href] === undefined) {
-                        links[e.href] = size;
-                    } else {
-                        links[e.href] += size;
+            if (rect.width > 1 && rect.height > 1 && (is_visible || !visibleOnly) && e) {
+                const url = e.href;
+                const baseUrl = url.split('#')[0]
+                if (baseUrl != testUrl && baseUrl != currentUrl) {
+                    if (sameOrigin(url, testUrl) || sameOrigin(url, currentUrl)) {
+                        let size = rect.width * rect.height;
+                        if (links[url] === undefined) {
+                            links[url] = size;
+                        } else {
+                            links[url] += size;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This considers both the original URL that WPT navigated to when testing as well as the current document's URL when crawling links to reduce cases where redirects are crawled twice.

Fix https://github.com/HTTPArchive/data-pipeline/issues/139

Sample test result: https://webpagetest.httparchive.org/result/230124_GN_1/

newlinks (with the change):
```json
[
	"https:\/\/almanac.httparchive.org\/en\/2022\/table-of-contents",
	"https:\/\/almanac.httparchive.org\/en\/2022\/methodology",
	"https:\/\/almanac.httparchive.org\/en\/2022\/contributors",
	"https:\/\/almanac.httparchive.org\/en\/2022\/seo",
	"https:\/\/almanac.httparchive.org\/en\/accessibility-statement",
	"https:\/\/almanac.httparchive.org\/en\/rss.xml"
]
```

crawl_links (current metric)
```json
[
	"https:\/\/almanac.httparchive.org\/en\/2022\/",
	"https:\/\/almanac.httparchive.org\/en\/2022\/table-of-contents",
	"https:\/\/almanac.httparchive.org\/en\/2022\/methodology",
	"https:\/\/almanac.httparchive.org\/en\/2022\/contributors",
	"https:\/\/almanac.httparchive.org\/en\/2022\/seo",
	"https:\/\/almanac.httparchive.org\/en\/2022\/#maincontent",
	"https:\/\/almanac.httparchive.org\/en\/accessibility-statement",
	"https:\/\/almanac.httparchive.org\/en\/rss.xml"
]
```