### PR TITLE
add nuxt_version to aurora metrics

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -11,7 +11,16 @@ function getAngularImagePriorityCount() {
     return document.querySelectorAll('img[ng-img][priority]').length;
 }
 
+// Detects Vue version for Nuxt apps
+// Nuxt doesn't expose its own version yet, but does expose its Vue version
+function getVueVersionForNuxt() {
+  const nuxt2Version = window.$nuxt?.$root?.constructor?.version;
+  const nuxt3Version = document.querySelector('#__nuxt')?.__vue_app__?.version;
+  return nuxt2Version || nuxt3Version;
+}
+
 return {
     ng_img_user: isAngularImageDirUser(),
-    ng_priority_img_count: getAngularImagePriorityCount()
+    ng_priority_img_count: getAngularImagePriorityCount(),
+    nuxt_version: getVueVersionForNuxt() || null
 };


### PR DESCRIPTION
Nuxt does not yet expose its own version data, but there is a way that we can grab Vue version data from Nuxt apps and extrapolate the Nuxt major version from that.

Note that it's not possible to query Nuxt apps for Vue version using the technologies table because
Nuxt removes the "normal" Vue version detection mechanism used by Wappalyzer (`window.Vue.version`).

Example WPT run: https://www.webpagetest.org/result/230203_AiDcFR_FYR/2/details/