### PR TITLE
add ng_version to aurora metrics

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -1,6 +1,12 @@
 //[aurora]
 // Uncomment the previous line for testing on webpagetest.org
 
+// Detects Angular version, which is added through runtime JS
+function getAngularVersion() {
+  const versionEl = document.querySelector('[ng-version]');
+  return versionEl?.getAttribute('ng-version');
+}
+
 // Detects if NgOptimizedImage is in use on the page
 function isAngularImageDirUser() {
   return !!document.querySelector('img[ng-img]');
@@ -20,6 +26,7 @@ function getVueVersionForNuxt() {
 }
 
 return {
+    ng_version: getAngularVersion() || null,
     ng_img_user: isAngularImageDirUser(),
     ng_priority_img_count: getAngularImagePriorityCount(),
     nuxt_version: getVueVersionForNuxt() || null


### PR DESCRIPTION
Angular adds version data to the DOM during
rendering, which means that it's not available
in the initial response data for CSR apps.
Adding this custom metric will allow us to
query Angular version distributions reliably
for both CSR and SSR apps.

Test run: https://www.webpagetest.org/result/230225_AiDc83_18/2/details/