### PR TITLE
add react version to aurora custom metrics

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -25,9 +25,15 @@ function getVueVersionForNuxt() {
   return nuxt2Version || nuxt3Version;
 }
 
+// Detects React version (set earlier by inject_script)
+function getReactVersion() {
+  return window.react_renderer_version;
+}
+
 return {
     ng_version: getAngularVersion() || null,
     ng_img_user: isAngularImageDirUser(),
     ng_priority_img_count: getAngularImagePriorityCount(),
-    nuxt_version: getVueVersionForNuxt() || null
+    nuxt_version: getVueVersionForNuxt() || null,
+    react_version: getReactVersion() || null
 };

--- a/inject-dist/aurora.js
+++ b/inject-dist/aurora.js
@@ -1,0 +1,9 @@
+
+// If set, React will call the provided inject() function to expose
+// version information. It can then be picked up by custom metrics.
+__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+  supportsFiber: true,
+  inject(renderer) {
+    window.react_renderer_version = renderer.version;
+  }
+}


### PR DESCRIPTION
This commit adds a:
- injection script that detects React version from renderer
- custom metric for exposing that React version

Closes #71 

See example test run [here](https://www.webpagetest.org/result/230228_BiDcVC_F7V/4/details/)