### PR TITLE
add nuxt version detection for nuxt 3.3+

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -27,7 +27,7 @@ function getVueVersionForNuxt() {
 
 // Detects Nuxt version directly for Nuxt 3.3 and later
 function getNuxtVersion() {
-  return __unctx__?.get('nuxt-app')?.use()?.versions.nuxt;
+  return __unctx__?.get('nuxt-app')?.use()?.versions?.nuxt;
 }
 
 // Detects React version (set earlier by inject_script)

--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -18,11 +18,16 @@ function getAngularImagePriorityCount() {
 }
 
 // Detects Vue version for Nuxt apps
-// Nuxt doesn't expose its own version yet, but does expose its Vue version
+// Nuxt only exposes its own version for Nuxt apps on v3.3+
 function getVueVersionForNuxt() {
   const nuxt2Version = window.$nuxt?.$root?.constructor?.version;
   const nuxt3Version = document.querySelector('#__nuxt')?.__vue_app__?.version;
   return nuxt2Version || nuxt3Version;
+}
+
+// Detects Nuxt version directly for Nuxt 3.3 and later
+function getNuxtVersion() {
+  return __unctx__?.get('nuxt-app')?.use()?.versions.nuxt;
 }
 
 // Detects React version (set earlier by inject_script)
@@ -34,6 +39,7 @@ return {
     ng_version: getAngularVersion() || null,
     ng_img_user: isAngularImageDirUser(),
     ng_priority_img_count: getAngularImagePriorityCount(),
-    nuxt_version: getVueVersionForNuxt() || null,
+    nuxt_version: getNuxtVersion() || null,
+    nuxt_vue_version: getVueVersionForNuxt() || null,
     react_version: getReactVersion() || null
 };


### PR DESCRIPTION
Nuxt 3.3.1 surfaces Nuxt version data. Through a
custom metric, we can now see Nuxt versions in
addition to Vue versions. This pattern is not
compatible with Wappalyzer, so a custom metric
is the only way to aggregate this data right
now.

Test run: https://www.webpagetest.org/result/230316_BiDcFV_C3D/1/details/