### PR TITLE
CMS: Add WordPress embed block counts by provider

### DIFF
--- a/dist/cms.js
+++ b/dist/cms.js
@@ -9,9 +9,26 @@ function hasWordPressEmbedBlock() {
   return !!document.querySelector('figure.wp-block-embed');
 }
 
+// Count the number of WordPress embed blocks on the page, including a breakdown by type
+function getWordPressEmbedBlockCounts() {
+  const embedBlocks = document.querySelectorAll('figure.wp-block-embed');
+  const embedsByType = [];
+  for ( let embed of embedBlocks ) {
+    let provider = embed.className.split( ' ' ).pop().split( "-" ).pop();
+    embedsByType[ provider ] = embedsByType[ provider ] || 0;
+    embedsByType[ provider ]++;
+  }
+
+  return {
+    total: embedBlocks.length,
+    total_by_type: embedsByType
+  }
+}
+
 const wordpress = {
   block_theme: usesBlockTheme(),
-  has_embed_block: hasWordPressEmbedBlock()
+  has_embed_block: hasWordPressEmbedBlock(),
+  embed_block_count: getWordPressEmbedBlockCounts()
 };
 
 return {

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -13,10 +13,20 @@ function hasWordPressEmbedBlock() {
 function getWordPressEmbedBlockCounts() {
   const embedBlocks = document.querySelectorAll('figure.wp-block-embed');
   const embedsByType = [];
-  for ( let embed of embedBlocks ) {
-    let provider = embed.className.split( ' ' ).pop().split( "-" ).pop();
-    embedsByType[ provider ] = embedsByType[ provider ] || 0;
-    embedsByType[ provider ]++;
+  for (let embed of embedBlocks) {
+    let embedClasses = embed.className.split( ' ' );
+
+    // Find the provider classname, which starts with "is-provider-".
+    let provider = embedClasses.find( function( className ) {
+      return className.startsWith( 'is-provider-' );
+    } );
+
+    if (provider) {
+      // Remove the "is-provider-" prefix to get the provider name.
+      provider = provider.replace( 'is-provider-', '' );
+      embedsByType[ provider ] = embedsByType[ provider ] || 0;
+      embedsByType[ provider ]++;
+    }
   }
 
   return {


### PR DESCRIPTION
This adds counts for embed blocks used on WordPress pages, including a breakdown of the source of the embed.

For example, running `getWordPressEmbedBlockCounts ` on this test page: 

https://oembeds-test.instawp.xyz/test-many-oembeds/

returns this data:

![image](https://user-images.githubusercontent.com/2676022/226739556-ccf4ef40-3b8b-46b0-bbb4-ad450ee9687c.png)

Note: the page includes two embeds of _other pages on the same site_, hence the provider shown as `oembeds-test-instawp-xyz: 2 `
