### PR TITLE
fix Nuxt version bug

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -27,7 +27,7 @@ function getVueVersionForNuxt() {
 
 // Detects Nuxt version directly for Nuxt 3.3 and later
 function getNuxtVersion() {
-  return __unctx__?.get('nuxt-app')?.use()?.versions?.nuxt;
+  return window['__unctx__']?.get('nuxt-app')?.use()?.versions?.nuxt;
 }
 
 // Detects React version (set earlier by inject_script)


### PR DESCRIPTION
Nuxt version detection was broken due to
the elvis operator not working properly
with a variable that ended in '__'.
Switching to use explicit square bracket
syntax resolves the issue.

Test run on non-Nuxt page:
https://www.webpagetest.org/result/230418_AiDcTX_2MH/1/details/