### PR TITLE
add error handling to avoid whole file breaks

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -1,6 +1,23 @@
 //[aurora]
 // Uncomment the previous line for testing on webpagetest.org
 
+// Wrap individual metric calls so errors don't break metrics in entire file.
+function runSafely(cb) {
+  try {
+    return cb() || null;
+  } catch (e) {
+    return logError(e);
+  }
+}
+
+function logError(e) {
+  try {
+    return `${e?.name}: ${e?.message}`;
+  } catch {
+    return null;
+  }
+}
+
 // Detects Angular version, which is added through runtime JS
 function getAngularVersion() {
   const versionEl = document.querySelector('[ng-version]');
@@ -36,10 +53,10 @@ function getReactVersion() {
 }
 
 return {
-    ng_version: getAngularVersion() || null,
-    ng_img_user: isAngularImageDirUser(),
-    ng_priority_img_count: getAngularImagePriorityCount(),
-    nuxt_version: getNuxtVersion() || null,
-    nuxt_vue_version: getVueVersionForNuxt() || null,
-    react_version: getReactVersion() || null
+    ng_version: runSafely(getAngularVersion),
+    ng_img_user: runSafely(isAngularImageDirUser),
+    ng_priority_img_count: runSafely(getAngularImagePriorityCount),
+    nuxt_version: runSafely(getNuxtVersion),
+    nuxt_vue_version: runSafely(getVueVersionForNuxt),
+    react_version: runSafely(getReactVersion)
 };

--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -12,7 +12,7 @@ function runSafely(cb) {
 
 function logError(e) {
   try {
-    return `${e?.name}: ${e?.message}`;
+    return `Error ${e?.name}: ${e?.message}`;
   } catch {
     return null;
   }


### PR DESCRIPTION
In a recent PR, all Aurora metrics were unavailable on some pages because an individual metric threw
an error. This PR adds basic error handling so each metric is isolated and can't break the whole file.

Nuxt test run: https://www.webpagetest.org/result/230419_AiDcWV_CCS/2/details/
Angular test run: https://www.webpagetest.org/result/230419_BiDcXX_BXE/2/details/
React test run:  https://www.webpagetest.org/result/230419_BiDcH4_2K3/1/details/

Test run with typo in two functions (typo manually added in WPT):  https://www.webpagetest.org/result/230419_AiDcSC_CCW/1/details/