### PR TITLE
Add custom metric for `html[lang]` attribute

### DIFF
--- a/dist/markup.js
+++ b/dist/markup.js
@@ -208,7 +208,7 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
     // Extract the <html lang=""> attribute value
     'lang': (() => {
       try {
-        return document.querySelector('html[lang]')?.getAttribute("lang") || null;
+        return document.querySelector('html[lang]')?.getAttribute("lang")
       }
       catch(e) {
         return logError("lang", e);

--- a/dist/markup.js
+++ b/dist/markup.js
@@ -205,6 +205,16 @@ try { // whole process is placed in a try/catch so we can log uncaught errors
       }
     })(),
 
+    // Extract the <html lang=""> attribute value
+    'lang': (() => {
+      try {
+        return document.querySelector('html[lang]')?.getAttribute("lang") || null;
+      }
+      catch(e) {
+        return logError("lang", e);
+      }
+    })(),
+
     // input tags
     // Used by Markup, 2019/09_28
     // refactor: https://github.com/HTTPArchive/legacy.httparchive.org/pull/177#discussion_r461976290


### PR DESCRIPTION
Extract the value of the `html[lang]` attribute to allow for easier comparison of sites with different languages.

Since country ≠ language, it's important to be able to detect the language information separately, and the `lang` attribute is the most useful indicator.
