### PR TITLE
detect bound priority attr usages

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -31,7 +31,7 @@ function isAngularImageDirUser() {
 
 // Detects count of NgOptimizedImage instances with a priority attr
 function getAngularImagePriorityCount() {
-    return document.querySelectorAll('img[ng-img][priority]').length;
+    return document.querySelectorAll('img[ng-img][fetchpriority=high]').length;
 }
 
 // Detects Vue version for Nuxt apps

--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -31,7 +31,7 @@ function isAngularImageDirUser() {
 
 // Detects count of NgOptimizedImage instances with a priority attr
 function getAngularImagePriorityCount() {
-    return document.querySelectorAll('img[ng-img][fetchpriority=high]').length;
+    return document.querySelectorAll('img[ng-img]:is([priority],[fetchpriority=high])').length;
 }
 
 // Detects Vue version for Nuxt apps


### PR DESCRIPTION
Previously, the ng_priority_img_count custom metric could only detect unbound usages of the "priority" attribute because it was checking for it directly. With this change, we check the "fetchpriority"
attribute instead because that will also catch
cases where the attribute was bound (in which case it disappears from the DOM).

Test run: https://www.webpagetest.org/result/230615_BiDc8T_DS5/1/details/ 