### PR TITLE
Add fetchpriority attribute usage to Images custom metric

### DIFF
--- a/dist/Images.js
+++ b/dist/Images.js
@@ -18,6 +18,7 @@ var wptImages = function (win) {
             naturalHeight: el.naturalHeight,
             loading: el.getAttribute("loading"),
             decoding: el.getAttribute("decoding"),
+            fetchpriority: el.getAttribute("fetchpriority"),
             inViewport:
               el.getBoundingClientRect().bottom >= 0 &&
               el.getBoundingClientRect().right >= 0 &&


### PR DESCRIPTION
This PR adds the `fetchpriority` attribute to the `Images` custom metric, allowing to monitor adoption and usage of the attribute and its values.