### PR TITLE
Add custom metrics for WordPress scripts

### DIFF
--- a/dist/cms.js
+++ b/dist/cms.js
@@ -67,6 +67,7 @@ function getWordPressScripts() {
       async: script.async,
       defer: script.defer,
       intended_strategy: script.dataset.wpStrategy || null,
+      // For each external script, check if there is a related inline script
       after_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-after`)),
       before_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-before`)),
       extra_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-extra`)),

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -35,10 +35,52 @@ function getWordPressEmbedBlockCounts() {
   }
 }
 
+/**
+ * Obtains data about scripts that WordPress prints on the page.
+ *
+ * @returns {{}[]}
+ */
+function getWordPressScripts() {
+  const entries = [];
+
+  /**
+   * Checks whether the provided element is an inline script.
+   *
+   * @param {?Element} element Element to examine. May be null.
+   * @return {?number} Size of the inline script or null if the element isn't an inline script.
+   */
+  const getInlineScriptSize = (element) => {
+    if (element instanceof HTMLScriptElement && !element.src) {
+      return element.textContent.length;
+    }
+    return null;
+  };
+
+  const scripts = document.querySelectorAll('script[src][id$="-js"]');
+  for (const script of scripts) {
+    /** @var HTMLScriptElement script */
+    const handle = script.id.replace(/-js$/, '');
+    entries.push({
+      handle,
+      src: script.src,
+      in_footer: script.parentNode !== document.head,
+      async: script.async,
+      defer: script.defer,
+      intended_strategy: script.dataset.wpStrategy || null,
+      after_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-after`)),
+      before_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-before`)),
+      extra_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-extra`)),
+      translations_script_size: getInlineScriptSize(document.getElementById(`${handle}-js-translations`)),
+    });
+  }
+  return entries;
+}
+
 const wordpress = {
   block_theme: usesBlockTheme(),
   has_embed_block: hasWordPressEmbedBlock(),
-  embed_block_count: getWordPressEmbedBlockCounts()
+  embed_block_count: getWordPressEmbedBlockCounts(),
+  scripts: getWordPressScripts(),
 };
 
 return {

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -44,10 +44,10 @@ function getWordPressScripts() {
   const entries = [];
 
   /**
-   * Checks whether the provided element is an inline script.
+   * Returns the number of characters in an inline script.
+   * Returns null for non-inlined scripts
    *
    * @param {?Element} element Element to examine. May be null.
-   * @return {?number} Size of the inline script or null if the element isn't an inline script.
    */
   const getInlineScriptSize = (element) => {
     if (element instanceof HTMLScriptElement && !element.src) {


### PR DESCRIPTION
This PR gathers data for scripts that WordPress prints to a page via `WP_Scripts`. As of WordPress 6.3, first-party support is finally landing for [`async` and `defer` scripts](https://core.trac.wordpress.org/ticket/12009). This custom metric will help track adoption, including whether the intended strategy (`async` or `defer`) was not able to be applied due to a dependency or an `after` inline script. 

I made an [example plugin](https://gist.github.com/westonruter/a195bfd69dd8bc7f1007ba25acb8366f) that dumps out various scenarios into a console table:

![image](https://github.com/HTTPArchive/custom-metrics/assets/134745/2778ca3e-eaa0-44e8-8592-60692e1ef5be)

I need to put that up on a test size to get the WebPageTest result.