### PR TITLE
Fix bug in WordPress embed block count

### DIFF
--- a/dist/cms.js
+++ b/dist/cms.js
@@ -12,7 +12,7 @@ function hasWordPressEmbedBlock() {
 // Count the number of WordPress embed blocks on the page, including a breakdown by type
 function getWordPressEmbedBlockCounts() {
   const embedBlocks = document.querySelectorAll('figure.wp-block-embed');
-  const embedsByType = [];
+  const embedsByType = {};
   for (let embed of embedBlocks) {
     let embedClasses = embed.className.split( ' ' );
 


### PR DESCRIPTION
Should be an object, not an array

[Old test](https://www.webpagetest.org/result/230711_BiDcCV_DZW/1/details/#waterfall_view_step1) fails:

**CMS**
```json
{"wordpress":{"block_theme":false,"has_embed_block":true,"embed_block_count":{"total":9,"total_by_type":[]}}}
```

[New Test](https://www.webpagetest.org/result/230711_BiDcED_E10/1/details/#waterfall_view_step1) succeeds:

**CMS**
```json
{"wordpress":{"block_theme":false,"has_embed_block":true,"embed_block_count":{"total":9,"total_by_type":{"youtube":9}}}}
```
