### PR TITLE
Add an `iframes` custom metric

### DIFF
--- a/dist/iframes.js
+++ b/dist/iframes.js
@@ -1,0 +1,28 @@
+var getIframes = function (win) {
+  var iframes = [];
+  if (win) {
+    var doc = win.document;
+    var elements = doc.getElementsByTagName("iframe");
+    for (var i = 0; i < elements.length; i++) {
+      var el = elements[i];
+      var url = el.currentSrc || el.src;
+
+      iframes.push({
+        url: url,
+        width: el.width,
+        height: el.height,
+        naturalWidth: el.naturalWidth,
+        naturalHeight: el.naturalHeight,
+        inViewport:
+          el.getBoundingClientRect().bottom >= 0 &&
+          el.getBoundingClientRect().right >= 0 &&
+          el.getBoundingClientRect().top <= window.innerHeight &&
+          el.getBoundingClientRect().left <= window.innerWidth,
+      });
+      if (iframes.length > 10000) break;
+    }
+  }
+  return iframes;
+};
+
+return JSON.stringify(getIframes(window));


### PR DESCRIPTION
Based on the images metric, this one enumerates iframes present on the page including their:
* url
* width & height
* naturalWidth and naturalHeight (for example when when w/h altered by CSS)
* inViewport