### PR TITLE
Fix custom metric JSON snippets in comments

### DIFF
--- a/.github/workflows/wpt-test.yml
+++ b/.github/workflows/wpt-test.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run WebPageTest for more websites
         run: |
           # Get the list of files that changed in the PR
-          METRICS=$(git diff --name-only --diff-filter=ACMRT ${GITHUB_BASE_SHA} ${GITHUB_HEAD_SHA} | \
+          METRICS=$(git diff --name-only --diff-filter=ACMRT origin/main | \
             grep -E "^dist/.*\.js$" | xargs -I {} basename {} | cut -d. -f1 | sort | uniq)
 
           # Get the PR body


### PR DESCRIPTION
[PR commenting](https://github.com/HTTPArchive/custom-metrics/pull/96#issuecomment-1777769835) is missing changed custom metrics JSON snippets.

Issue was related to git diff command.
Now using `origin/main` as a more straightforward pointer to a commit.