### PR TITLE
Fail the test if the test redirected to a cross-origin page

### DIFF
--- a/dist/test_result.js
+++ b/dist/test_result.js
@@ -9,7 +9,7 @@ const sameOrigin = function(uri1, uri2){
   return false;
 }
 const testUrl = $WPT_TEST_URL;
-const currentUrl = document.location.href.split('#')[0];
+const currentUrl = document.location.href;
 if (sameOrigin(testUrl, currentUrl)) {
   return 0;  // No change
 }


### PR DESCRIPTION
This uses a new agent feature where the test result can be overridden by a custom metric named `test_result` to fail any test that ends up on a different origin from where the test started.

Sample test of https://www.google.com/ (successful) - [here](https://webpagetest.httparchive.org/result/231204_PQ_2/)
Sample test of http://www.google.com/ (failed) - [here](https://webpagetest.httparchive.org/result/231204_TB_3/)

![Screenshot 2023-12-04 at 4 54 35 PM](https://github.com/HTTPArchive/custom-metrics/assets/444165/b4e229b8-fdf3-4619-8af6-d0278797dccd)
