### PR TITLE
Test LCP viewport stat

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -24,7 +24,7 @@ function getLcpElement() {
             resolve(naiveLcpEntry);
         }).observe({ type: "largest-contentful-paint", buffered: true });
     }).then(({ startTime, element, url, size, loadTime, renderTime }) => {
-        const cover90viewport = doesElementCoverPercentageOfViewport(element, 90);
+        const cover90viewport = doesElementCoverPercentageOfViewport(element, 0.9);
         const attributes = getAttributes(element);
         const styles = getAllStyles(element, ['background-image', 'pointer-events', 'position', 'width', 'height']);
         return {
@@ -168,7 +168,7 @@ function getGamingMetrics(rawDoc, lcp_elem_stats) {
             }
         }
 
-        returnObj['fidIframeOverlaySoft'] = doesElementCoverPercentageOfViewport(iframeElement, 90);
+        returnObj['fidIframeOverlaySoft'] = doesElementCoverPercentageOfViewport(iframeElement, 0.9);
 
     });
 
@@ -187,20 +187,14 @@ function getGamingMetrics(rawDoc, lcp_elem_stats) {
     return returnObj;
 }
 
-// Source: https://stackoverflow.com/questions/57786082/determine-how-much-of-the-viewport-is-covered-by-element-intersectionobserver
-// percentage is a whole number (ex: 90, not .9)
 function doesElementCoverPercentageOfViewport(element, percentage) {
-        const percentOfViewport = getPercentOfViewport(element) * 100;
-
-        if (percentOfViewport > percentage) {
-            return true;
-        }
-        return false;
+    return getPercentOfViewport(element) > percentage;
 }
 
+// Source: https://stackoverflow.com/questions/57786082/determine-how-much-of-the-viewport-is-covered-by-element-intersectionobserver
 function getPercentOfViewport(element) {
-        const elementBCR = element.getBoundingClientRect();
-        return ((elementBCR.width * elementBCR.height * calcOcclusion(elementBCR)) / (window.innerWidth * window.innerHeight)).toPrecision(3);
+    const elementBCR = element.getBoundingClientRect();
+    return ((elementBCR.width * elementBCR.height * calcOcclusion(elementBCR)) / (window.innerWidth * window.innerHeight)).toPrecision(3);
 }
 
 // Calculate Element : Viewport Intersection ratio without Intersection Observer

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -28,12 +28,12 @@ function getLcpElement() {
         const attributes = getAttributes(element);
         const styles = getAllStyles(element, ['background-image', 'pointer-events', 'position', 'width', 'height']);
         return {
-            startTime,
+            startTime: startTime.toPrecision(3),
             nodeName: element?.nodeName,
             url,
             size,
-            loadTime,
-            renderTime,
+            loadTime: loadTime.toPrecision(3),
+            renderTime: renderTime.toPrecision(3),
             attributes,
             boundingClientRect: element?.getBoundingClientRect().toJSON(),
             naturalWidth: element?.naturalWidth,
@@ -200,7 +200,7 @@ function doesElementCoverPercentageOfViewport(element, percentage) {
 
 function getPercentOfViewport(element) {
         const elementBCR = element.getBoundingClientRect();
-        return (elementBCR.width * elementBCR.height * calcOcclusion(elementBCR)) / (window.innerWidth * window.innerHeight);
+        return ((elementBCR.width * elementBCR.height * calcOcclusion(elementBCR)) / (window.innerWidth * window.innerHeight)).toPrecision(3);
 }
 
 // Calculate Element : Viewport Intersection ratio without Intersection Observer

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -39,6 +39,7 @@ function getLcpElement() {
             naturalWidth: element?.naturalWidth,
             naturalHeight: element?.naturalHeight,
             styles,
+            percentOfViewport: getPercentOfViewport(element),
             cover90viewport
         };
     });
@@ -210,13 +211,17 @@ function getGamingMetrics(rawDoc, lcp_elem_stats) {
 // Source: https://stackoverflow.com/questions/57786082/determine-how-much-of-the-viewport-is-covered-by-element-intersectionobserver
 // percentage is a whole number (ex: 90, not .9)
 function doesElementCoverPercentageOfViewport(element, percentage) {
-        const elementBCR = element.getBoundingClientRect();
-        const percentOfViewport = ((elementBCR.width * elementBCR.height) * calcOcclusion(elementBCR)) / ((window.innerWidth * window.innerHeight) / 100);
+        const percentOfViewport = getPercentOfViewport(element);
 
         if (percentOfViewport > percentage) {
             return true;
         }
         return false;
+}
+
+function getPercentOfViewport(element) {
+        const elementBCR = element.getBoundingClientRect();
+        return elementBCR.width * elementBCR.height * calcOcclusion(elementBCR) / window.innerWidth * window.innerHeight;
 }
 
 // Calculate Element : Viewport Intersection ratio without Intersection Observer

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -221,7 +221,7 @@ function doesElementCoverPercentageOfViewport(element, percentage) {
 
 function getPercentOfViewport(element) {
         const elementBCR = element.getBoundingClientRect();
-        return elementBCR.width * elementBCR.height * calcOcclusion(elementBCR) / window.innerWidth * window.innerHeight;
+        return (elementBCR.width * elementBCR.height * calcOcclusion(elementBCR)) / (window.innerWidth * window.innerHeight);
 }
 
 // Calculate Element : Viewport Intersection ratio without Intersection Observer

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -67,29 +67,8 @@ function getComputedStyles(element, properties) {
     return Object.fromEntries(properties.map(prop => ([prop, styles.getPropertyValue(prop)])));
 }
 
-function getInlineStyles (element, properties) {
-    if (!element) {
-        return null;
-    }
-
-    const styles = element.style;
-    return Object.fromEntries(properties.map(prop => ([prop, styles.getPropertyValue(prop)])));
-}
-
-// Merge Inline styles with Computed styles.
-// Inline has higher specificty, unless '!important' exists in computed styles.
 function getAllStyles(element, properties) {
-    const inlineStyles = getInlineStyles(element, properties);
-    const computedStyles = getComputedStyles(element, properties);
-    const allStyles = {};
-    for (const styleName in inlineStyles) {
-        if (!inlineStyles[styleName].includes('!important') && computedStyles.hasOwnProperty(styleName) && computedStyles[styleName].includes('!important')) {
-            allStyles[styleName] = computedStyles[styleName];
-        } else {
-            allStyles[styleName] = inlineStyles[styleName];
-        }
-    }
-    return allStyles;
+    return getComputedStyles(element, properties);
 }
 
 function summarizeElement(element) {

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -190,7 +190,7 @@ function getGamingMetrics(rawDoc, lcp_elem_stats) {
 // Source: https://stackoverflow.com/questions/57786082/determine-how-much-of-the-viewport-is-covered-by-element-intersectionobserver
 // percentage is a whole number (ex: 90, not .9)
 function doesElementCoverPercentageOfViewport(element, percentage) {
-        const percentOfViewport = getPercentOfViewport(element);
+        const percentOfViewport = getPercentOfViewport(element) * 100;
 
         if (percentOfViewport > percentage) {
             return true;

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -28,12 +28,12 @@ function getLcpElement() {
         const attributes = getAttributes(element);
         const styles = getAllStyles(element, ['background-image', 'pointer-events', 'position', 'width', 'height']);
         return {
-            startTime: startTime.toPrecision(3),
+            startTime,
             nodeName: element?.nodeName,
             url,
             size,
-            loadTime: loadTime.toPrecision(3),
-            renderTime: renderTime.toPrecision(3),
+            loadTime,
+            renderTime,
             attributes,
             boundingClientRect: element?.getBoundingClientRect().toJSON(),
             naturalWidth: element?.naturalWidth,


### PR DESCRIPTION
Fixes for the `performance` custom metric:
- getComputedStyle already handles specificity/importance so no need to merge with inline styles
- percentage of viewport should be `* 100` to make it an int, not `/ 100`

Also outputs the LCP viewport percentage as a standalone field

**Test websites**:
- https://maxiclimber.com/
- https://fancy-confused-apparel.glitch.me/