### PR TITLE
Add feature flag metric

### DIFF
--- a/dist/aurora.js
+++ b/dist/aurora.js
@@ -57,6 +57,19 @@ function getSvelteVersion() {
   return window.__svelte?.v ? Array.from(window.__svelte?.v).toString() : null;
 }
 
+// Detects standard feature flag usage
+function getFeatureFlags() {
+  function getFeatureNames(name) {
+    return window.performance.getEntriesByName(name).map(mark => mark.detail?.feature).filter(Boolean);
+  }
+
+  return Array.from(new Set([
+    // Some frameworks used the old name before it changed
+    ...getFeatureNames("mark_use_counter"),
+    ...getFeatureNames("mark_feature_usage"),
+  ]));
+}
+
 return {
     ng_version: runSafely(getAngularVersion),
     ng_img_user: runSafely(isAngularImageDirUser),
@@ -64,5 +77,6 @@ return {
     nuxt_version: runSafely(getNuxtVersion),
     nuxt_vue_version: runSafely(getVueVersionForNuxt),
     react_version: runSafely(getReactVersion),
-    svelte_version: runSafely(getSvelteVersion)
+    svelte_version: runSafely(getSvelteVersion),
+    feature_flags: runSafely(getFeatureFlags),
 };


### PR DESCRIPTION
The [`detail` field](https://developer.mozilla.org/en-US/docs/Web/API/Performance/mark#detail) in `performance.mark` doesn't seem to be available in HTTP Archive, so this PR adds a custom metric that extracts a set of feature names according to the [User Timing specification](https://w3c.github.io/user-timing/#dfn-mark_feature_usage). This also includes support for the [previous name](https://github.com/w3c/user-timing/pull/108), since some pages are using it.

**Test websites**:

- https://angular.io/
- https://angular.dev/
- https://svelte.dev/