### PR TITLE
Add custom metric to measure generated content (size and percent)

### DIFF
--- a/dist/generated-content.js
+++ b/dist/generated-content.js
@@ -13,7 +13,7 @@ if (htmlInitial && htmlAfter) {
   generatedContent = (htmlAfterSize - htmlInitialSize) / 1024;
 }
 
-return { 
+return JSON.stringify({
   percent: generatedContentPercent.toFixed(2),
-  sizeInKB: generatedContent.toFixed(2)
-}
+  sizeInKB: generatedContent.toFixed(2),
+});

--- a/dist/generated-content.js
+++ b/dist/generated-content.js
@@ -9,11 +9,11 @@ let htmlAfter = document.documentElement.outerHTML;
 if (htmlInitial && htmlAfter) {
   let htmlInitialSize = byteSize(htmlInitial);
   let htmlAfterSize = byteSize(htmlAfter);
-  generatedContentPercent = 100 - (htmlInitialSize / htmlAfterSize) * 100;
+  generatedContentPercent = 1 - (htmlInitialSize / htmlAfterSize);
   generatedContent = (htmlAfterSize - htmlInitialSize) / 1024;
 }
 
-return JSON.stringify({
-  percent: generatedContentPercent.toFixed(2),
+return {
+  percent: generatedContentPercent.toFixed(4),
   sizeInKB: generatedContent.toFixed(2),
-});
+};

--- a/dist/generated-content.js
+++ b/dist/generated-content.js
@@ -1,0 +1,19 @@
+let generatedContentPercent = 0;
+let generatedContent = 0;
+
+const byteSize = (str) => new Blob([str]).size;
+
+let htmlInitial = $WPT_BODIES[0].response_body;
+let htmlAfter = document.documentElement.outerHTML;
+
+if (htmlInitial && htmlAfter) {
+  let htmlInitialSize = byteSize(htmlInitial);
+  let htmlAfterSize = byteSize(htmlAfter);
+  generatedContentPercent = 100 - (htmlInitialSize / htmlAfterSize) * 100;
+  generatedContent = (htmlAfterSize - htmlInitialSize) / 1024;
+}
+
+return { 
+  percent: generatedContentPercent.toFixed(2),
+  sizeInKB: generatedContent.toFixed(2)
+}


### PR DESCRIPTION
Adds support for `generated-content` custom metric that includes percentage and size in KB. This is helpful to recognize web pages that rely on JavaScript for generating most of the content, such as [CSR](https://www.patterns.dev/react/client-side-rendering/) apps.

As an example, see `01_test` custom metric in the following runs:
- [SSR - imkev.dev](https://www.webpagetest.org/result/240118_AiDc8Z_BZ3/1/details/)

```js
{"percent":"8.55","sizeInKB":"2.42"}	
```

- [CSR - pesuar.com/](https://www.webpagetest.org/result/240118_AiDcK3_BZ7/1/details/)

```js
{"percent":"85.40","sizeInKB":"19.92"}
```

---

**Test websites**:

- https://imkev.dev/
- https://pesuar.com/
