### PR TITLE
Add custom metrics for the WordPress Interactivity API

### DIFF
--- a/dist/cms.js
+++ b/dist/cms.js
@@ -151,12 +151,31 @@ function getWordPressContentType() {
   return content;
 }
 
+/**
+ * Obtains data about Interactivity API elements on the page..
+ *
+ * @returns {{}[]}
+ */
+function getInteractivityAPIData() {
+  // Look for data-wp-interactive elements.
+  const interactiveElements = document.querySelectorAll('[data-wp-interactive]');
+
+  return {
+    usesInteractivityAPI: interactiveElements.length > 0,
+    interactiveElementsCount: interactiveElements.length,
+    interactiveElements: Array.from(interactiveElements).map((element) => {
+      return element.dataset.wpInteractive;
+    } )
+  };
+}
+
 const wordpress = {
   block_theme: usesBlockTheme(),
   has_embed_block: hasWordPressEmbedBlock(),
   embed_block_count: getWordPressEmbedBlockCounts(),
   scripts: getWordPressScripts(),
   content_type: getWordPressContentType(),
+  interactivity_api: getInteractivityAPIData(),
 };
 
 return {

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -154,7 +154,7 @@ function getWordPressContentType() {
 /**
  * Obtains data about Interactivity API elements on the page..
  *
- * @returns {{}[]}
+ * @returns {object} Object with fields `usesInteractivityAPI`, `interactiveElementsCount`, and `interactiveElements`.
  */
 function getInteractivityAPIData() {
   // Look for data-wp-interactive elements.

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -152,12 +152,12 @@ function getWordPressContentType() {
 }
 
 /**
- * Obtains data about Interactivity API elements on the page..
+ * Obtains data about Interactivity API regions on the page.
  *
  * @returns {object} Object with fields `total` and `total_by_type`.
  */
 function getInteractivityAPIRegionCounts() {
-  // Look for data-wp-interactive elements.
+  // Look for data-wp-interactive regions.
   const interactiveRegions = document.querySelectorAll('[data-wp-interactive]');
 
   // Count the regions by type.

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -161,7 +161,7 @@ function getInteractivityAPIUsage() {
   const interactiveRegions = document.querySelectorAll('[data-wp-interactive]');
 
   // Count the regions by namespace.
-  const regionNamespaceCounts = {}
+  const regionNamespaceCounts = {};
   interactiveRegions.forEach( region => {
     // Extract the namespace from JSON or as a string
     let namespace = '';

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -152,24 +152,24 @@ function getWordPressContentType() {
 }
 
 /**
- * Obtains data about Interactivity API regions on the page.
+ * Obtains data about Interactivity API usage on the page.
  *
- * @returns {object} Object with fields `total` and `total_by_type`.
+ * @returns {object} Object with fields `total_regions` and `total_regions_by_namespace`.
  */
-function getInteractivityAPIRegionCounts() {
+function getInteractivityAPIUsage() {
   // Look for data-wp-interactive regions.
   const interactiveRegions = document.querySelectorAll('[data-wp-interactive]');
 
-  // Count the regions by type.
-  const regionTypeCounts = [];
+  // Count the regions by namespace.
+  const regionNamespaceCounts = [];
   interactiveRegions.forEach( region => {
-    const type = region.getAttribute('data-wp-interactive');
-    regionTypeCounts[ type ] = ( regionTypeCounts[ type ] || 0 ) + 1;
+    const namespace = region.getAttribute('data-wp-interactive');
+    regionNamespaceCounts[ namespace ] = ( regionNamespaceCounts[ namespace ] || 0 ) + 1;
   })
 
   return {
-    total: interactiveRegions.length,
-    total_by_type: regionTypeCounts,
+    total_regions: interactiveRegions.length,
+    total_regions_by_namespace: regionNamespaceCounts,
   };
 }
 
@@ -189,7 +189,7 @@ const wordpress = {
   scripts: getWordPressScripts(),
   content_type: getWordPressContentType(),
   uses_interactivity_api: usesInteractivityAPI(),
-  interactivity_api_region_count: getInteractivityAPIRegionCounts(),
+  interactivity_api_usage: getInteractivityAPIUsage(),
 };
 
 return {

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -174,7 +174,7 @@ function getInteractivityAPIUsage() {
     } catch ( e ) {
       namespace = regionAttribute;
     }
-    if ( '' !== namespace ) {
+    if ( 'string' === typeof namespace && '' !== namespace ) {
       regionNamespaceCounts[ namespace ] = ( regionNamespaceCounts[ namespace ] || 0 ) + 1;
     }
   })

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -154,9 +154,9 @@ function getWordPressContentType() {
 /**
  * Obtains data about Interactivity API elements on the page..
  *
- * @returns {object} Object with fields `usesInteractivityAPI`, `interactiveRegionsCount`, and `interactiveRegionTypeCounts`.
+ * @returns {object} Object with fields `total` and `total_by_type`.
  */
-function getInteractivityAPIData() {
+function getInteractivityAPIRegionCounts() {
   // Look for data-wp-interactive elements.
   const interactiveRegions = document.querySelectorAll('[data-wp-interactive]');
 
@@ -168,10 +168,18 @@ function getInteractivityAPIData() {
   })
 
   return {
-    usesInteractivityAPI: interactiveRegions.length > 0,
-    interactiveRegionsCount: interactiveRegions.length,
-    interactiveRegionTypeCounts: regionTypeCounts,
+    total: interactiveRegions.length,
+    total_by_type: regionTypeCounts,
   };
+}
+
+/**
+ * Check if the page uses the interactivity API.
+ *
+ * @returns {boolean} Whether any interactivity API regions are present.
+ */
+function usesInteractivityAPI() {
+  return !!document.querySelector('[data-wp-interactive]');
 }
 
 const wordpress = {
@@ -180,7 +188,8 @@ const wordpress = {
   embed_block_count: getWordPressEmbedBlockCounts(),
   scripts: getWordPressScripts(),
   content_type: getWordPressContentType(),
-  interactivity_api: getInteractivityAPIData(),
+  uses_interactivity_api: usesInteractivityAPI(),
+  interactivity_api_region_count: getInteractivityAPIRegionCounts(),
 };
 
 return {

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -163,8 +163,20 @@ function getInteractivityAPIUsage() {
   // Count the regions by namespace.
   const regionNamespaceCounts = [];
   interactiveRegions.forEach( region => {
-    const namespace = region.getAttribute('data-wp-interactive');
-    regionNamespaceCounts[ namespace ] = ( regionNamespaceCounts[ namespace ] || 0 ) + 1;
+    // Extract the namespace from JSON or as a string
+    var namespace = '';
+    const regionAttribute = region.getAttribute('data-wp-interactive');
+    try {
+      const regionData = JSON.parse( regionAttribute );
+      if ( regionData.namespace && 'string' === typeof regionData.namespace ) {
+        namespace = regionData.namespace;
+      }
+    } catch ( e ) {
+      namespace = regionAttribute;
+    }
+    if ( '' !== namespace ) {
+      regionNamespaceCounts[ namespace ] = ( regionNamespaceCounts[ namespace ] || 0 ) + 1;
+    }
   })
 
   return {

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -161,7 +161,7 @@ function getInteractivityAPIUsage() {
   const interactiveRegions = document.querySelectorAll('[data-wp-interactive]');
 
   // Count the regions by namespace.
-  const regionNamespaceCounts = [];
+  const regionNamespaceCounts = {}
   interactiveRegions.forEach( region => {
     // Extract the namespace from JSON or as a string
     let namespace = '';

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -164,7 +164,7 @@ function getInteractivityAPIUsage() {
   const regionNamespaceCounts = [];
   interactiveRegions.forEach( region => {
     // Extract the namespace from JSON or as a string
-    var namespace = '';
+    let namespace = '';
     const regionAttribute = region.getAttribute('data-wp-interactive');
     try {
       const regionData = JSON.parse( regionAttribute );

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -154,18 +154,23 @@ function getWordPressContentType() {
 /**
  * Obtains data about Interactivity API elements on the page..
  *
- * @returns {object} Object with fields `usesInteractivityAPI`, `interactiveElementsCount`, and `interactiveElements`.
+ * @returns {object} Object with fields `usesInteractivityAPI`, `interactiveRegionsCount`, and `interactiveRegionTypeCounts`.
  */
 function getInteractivityAPIData() {
   // Look for data-wp-interactive elements.
-  const interactiveElements = document.querySelectorAll('[data-wp-interactive]');
+  const interactiveRegions = document.querySelectorAll('[data-wp-interactive]');
+
+  // Count the regions by type.
+  const regionTypeCounts = [];
+  interactiveRegions.forEach( region => {
+    const type = region.getAttribute('data-wp-interactive');
+    regionTypeCounts[ type ] = ( regionTypeCounts[ type ] || 0 ) + 1;
+  })
 
   return {
-    usesInteractivityAPI: interactiveElements.length > 0,
-    interactiveElementsCount: interactiveElements.length,
-    interactiveElements: Array.from(interactiveElements).map((element) => {
-      return element.dataset.wpInteractive;
-    } )
+    usesInteractivityAPI: interactiveRegions.length > 0,
+    interactiveRegionsCount: interactiveRegions.length,
+    interactiveRegionTypeCounts: regionTypeCounts,
   };
 }
 


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->
Collect data about usage of the WordPress interactivity API, which recently shipped in WordPress 6.5 (see https://make.wordpress.org/core/2024/03/04/interactivity-api-dev-note/)

Adds two new datapoints to the cms/wordpress custom metric:
* `uses_interactivity_api` - does the page uses the Interactivity API?
* `interactivity_api_region_count` - an array with the total region count as well as the region count by type.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://interactivity-api.instawp.xyz/test-post/

Current results: 
<img src="https://github.com/HTTPArchive/custom-metrics/assets/2676022/65913bd4-eb52-4154-9438-b462f702e80c" width="450" />