### PR TITLE
[Performance 2024] Added bytesPerPixel (BPP) property to Images custom metric

### DIFF
--- a/dist/Images.js
+++ b/dist/Images.js
@@ -24,6 +24,11 @@ var wptImages = function (win) {
               el.getBoundingClientRect().right >= 0 &&
               el.getBoundingClientRect().top <= window.innerHeight &&
               el.getBoundingClientRect().left <= window.innerWidth,
+            bytesPerPixel:
+              (performance.getEntriesByName(el.currentSrc)[0]
+                ?.encodedBodySize *
+                8) /
+              (el.width * el.height),
           });
         }
       }


### PR DESCRIPTION
Add `bytesPerPixel` custom metric. This is calculated as (filesize in bits) / (image display height * image display width)

**[Note that it would return `0` for cross-origin images that do not include the `timing-allow-origin` header.](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/encodedBodySize#value)**

---
**Test websites**:

- https://web.dev
- https://almanac.httparchive.org/
