### PR TITLE
Added a custom metric to store local and session storage keys and val…

### DIFF
--- a/dist/local_session_storage_key_values.js
+++ b/dist/local_session_storage_key_values.js
@@ -1,0 +1,14 @@
+function getLocalStorageKeyValues() {
+  return { ...localStorage };
+}
+
+function getSessionStorageKeyValues() {
+  return { ...sessionStorage };
+}
+
+const storageData = {
+  allLocalStorage: getLocalStorageKeyValues(),
+  allSessionStorage: getSessionStorageKeyValues()
+}
+
+return storageData;


### PR DESCRIPTION
This PR adds a new custom metric to capture and return all key-value pairs from localStorage and sessionStorage of the first-party website.

Changes

- Added ```getLocalStorageKeyValues``` function to retrieve all key-value pairs from localStorage.
- Added ```getSessionStorageKeyValues``` function to retrieve all key-value pairs from sessionStorage.
- Aggregated the results of both functions into a single object storageData to return for storage.

Testing was done on the ```webpagetest.org```.