### PR TITLE
Added a custom metric to store local and session storage keys and val…

### DIFF
--- a/dist/local_session_storage_key_values.js
+++ b/dist/local_session_storage_key_values.js
@@ -1,9 +1,19 @@
 function getLocalStorageKeyValues() {
-  return { ...localStorage };
+  return Object.keys(localStorage)
+    .reduce((obj, key) => {
+      const value = localStorage.getItem(key);
+      obj[key] = value ? value.substring(0, 256) : value;
+      return obj;
+    }, {});
 }
 
 function getSessionStorageKeyValues() {
-  return { ...sessionStorage };
+  return Object.keys(sessionStorage)
+    .reduce((obj, key) => {
+      const value = sessionStorage.getItem(key);
+      obj[key] = value ? value.substring(0, 256) : value;
+      return obj;
+    }, {});
 }
 
 const storageData = {

--- a/dist/local_session_storage_key_values.js
+++ b/dist/local_session_storage_key_values.js
@@ -1,0 +1,14 @@
+function getLocalStorageKeyValues() {
+  return { ...localStorage };
+}
+
+function getSessionStorageKeyValues() {
+  return { ...sessionStorage };
+}
+
+const storageData = {
+  allLocalStorage: getLocalStorageKeyValues(),
+  allSessionStorage: getSessionStorageKeyValues()
+}
+
+return storageData;

--- a/dist/local_storage_api_calls.js
+++ b/dist/local_storage_api_calls.js
@@ -1,0 +1,18 @@
+const response_bodies = $WPT_BODIES;
+const storagePattern = /\b(localStorage|sessionStorage)\b/g;
+
+return Object.fromEntries(response_bodies.filter(har => {
+  return storagePattern.test(har.response_body);
+}).map(har => {
+  const matches = Array.from(har.response_body.matchAll(storagePattern));
+  const counts = matches.reduce((acc, match) => {
+    const key = match[0];
+    if (!acc[key]) {
+      acc[key] = 0;
+    }
+    acc[key]++;
+    return acc;
+  }, { numLocalStorage: 0, numSessionStorage: 0 });
+
+  return [har.url, { numLocalStorage: counts.localStorage || 0, numSessionStorage: counts.sessionStorage || 0 }];
+}));

--- a/dist/localstorage_size.js
+++ b/dist/localstorage_size.js
@@ -1,7 +1,7 @@
 function storageSize(storage) {
   var numkeys = numKeys(storage);
   var bytes = 0;
-  for ( var i = 0; i < numkeys; i++ ) {
+  for (var i = 0; i < numkeys; i++) {
     var key = storage.key(i);
     var val = storage.getItem(key);
     bytes += key.length + val.length;
@@ -10,12 +10,12 @@ function storageSize(storage) {
 }
 
 function numKeys(storage) {
-  if ( "undefined" != typeof(storage.length) ) {
+  if ("undefined" != typeof (storage.length)) {
     return storage.length;
   }
   else {
     len = 0;
-    for ( var key in storage ) {
+    for (var key in storage) {
       len++;
     }
     return len;


### PR DESCRIPTION
This PR adds a new custom metric to capture and return all key-value pairs from `localStorage` and `sessionStorage` of the first-party website.

## Changes

- Added `getLocalStorageKeyValues` function to retrieve all key-value pairs from localStorage.
- Added `getSessionStorageKeyValues` function to retrieve all key-value pairs from sessionStorage.
- Aggregated the results of both functions into a single object `storageData` to return for storage.

Testing was done on the `webpagetest.org.`

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://tmz.com
- https://cnn.com
