### PR TITLE
added a custom metric to store the number of localstorage and session…

### DIFF
--- a/dist/local_storage_api_calls.js
+++ b/dist/local_storage_api_calls.js
@@ -1,18 +1,23 @@
 const response_bodies = $WPT_BODIES;
-const storagePattern = /\b(localStorage|sessionStorage)\b/g;
+const storagePattern = /\b(localStorage|sessionStorage)\b(\.\w+)?/g;
 
 return Object.fromEntries(response_bodies.filter(har => {
   return storagePattern.test(har.response_body);
 }).map(har => {
   const matches = Array.from(har.response_body.matchAll(storagePattern));
   const counts = matches.reduce((acc, match) => {
-    const key = match[0];
-    if (!acc[key]) {
-      acc[key] = 0;
+    const key = match[1];
+    const access = match[2];
+
+    if (access && (access.startsWith('.getItem') || access.startsWith('.setItem') || access.startsWith('.removeItem'))) {
+      if (!acc[key]) {
+        acc[key] = 0;
+      }
+      acc[key]++;
     }
-    acc[key]++;
+
     return acc;
-  }, { numLocalStorage: 0, numSessionStorage: 0 });
+  }, { localStorage: 0, sessionStorage: 0 });
 
   return [har.url, { numLocalStorage: counts.localStorage || 0, numSessionStorage: counts.sessionStorage || 0 }];
 }));

--- a/dist/local_storage_api_calls.js
+++ b/dist/local_storage_api_calls.js
@@ -1,0 +1,18 @@
+const response_bodies = $WPT_BODIES;
+const storagePattern = /\b(localStorage|sessionStorage)\b/g;
+
+return Object.fromEntries(response_bodies.filter(har => {
+  return storagePattern.test(har.response_body);
+}).map(har => {
+  const matches = Array.from(har.response_body.matchAll(storagePattern));
+  const counts = matches.reduce((acc, match) => {
+    const key = match[0];
+    if (!acc[key]) {
+      acc[key] = 0;
+    }
+    acc[key]++;
+    return acc;
+  }, { numLocalStorage: 0, numSessionStorage: 0 });
+
+  return [har.url, { numLocalStorage: counts.localStorage || 0, numSessionStorage: counts.sessionStorage || 0 }];
+}));


### PR DESCRIPTION
This pull request adds a new custom metric that logs how many times `localStorage` and `sessionStorage` was accessed in each response body in `$WPT_BODIES`. It returns a dictionary with the keys containing URLs and the values containing another dictionary containing `numLocalStorage` and `numSessionStorage`, with the former representing the number of times `localStorage` API was accessed while the later representing how many times `sessionStorage` API was accessed.

The code was tested on `webpagetest.org`.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://tmz.com
- https://cnn.com