### PR TITLE
Security 2024 Updated security.txt Metric

### DIFF
--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -169,9 +169,11 @@ return Promise.all([
         } else if (line.startsWith('CSAF: ')) {
           data['csaf'].push(line.substring(6).trim());
         } else {
-          let [name, value] = line.split(': ');
-          if (name && value) {
-            data['other'].push([name.trim(), value.trim()]);
+          if (!line.startsWith('#')) {
+            let [name, value] = line.split(': ');
+            if (name && value) {
+              data['other'].push([name.trim(), value.trim()]);
+            }
           }
         }
       }   

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -176,8 +176,18 @@ return Promise.all([
             }
           }
         }
-      }   
-      // Optional
+      }
+      // Required fields exist
+      data['all_required_exist'] = (data['contact'].length && data['expires'].length) > 0;
+      // Fields that are only allowed once do not occur twice
+      data['only_one_requirement_broken'] = false;
+      for (let field of ['expires', 'preferred_languages']) {
+        if (data[field].length > 1) {
+          data['only_one_requirement_broken'] = true;
+        }
+      }
+      // Valid: Required fields exist and only one requirement is not broken. Does not check value content at the moment (e.g., if expires is a valid ISO 8601 date).
+      data['valid'] = data['all_required_exist'] && (!data['only_one_requirement_broken'])
       return data;
     });
   }),

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -139,17 +139,43 @@ return Promise.all([
       if (text.startsWith('-----BEGIN PGP SIGNED MESSAGE-----')) {
         data['signed'] = true;
       }
-      for(let line of text.split('\n')) {
-        if (line.startsWith('Canonical: ')) {
-          data['canonical'] = line.substring(11);
-        } else if (line.startsWith('Encryption: ')) {
-          data['encryption'] = line.substring(12);
+      data['contact'] = [];
+      data['expires'] = [];
+      data['encryption'] = [];
+      data['acknowledgments'] = [];
+      data['preferred_languages'] = [];
+      data['canonical'] = [];
+      data['policy'] = [];
+      data['hiring'] = [];
+      data['csaf'] = [];
+      data['other'] = []; // [(name, value)]
+      for (let line of text.split('\n')) {
+        if (line.startsWith('Contact: ')) {
+          data['contact'].push(line.substring(9).trim());
         } else if (line.startsWith('Expires: ')) {
-          data['expires'] = line.substring(9);
+          data['expires'].push(line.substring(9).trim());
+        } else if (line.startsWith('Encryption: ')) {
+          data['encryption'].push(line.substring(12).trim());
+        } else if (line.startsWith('Acknowledgments: ')) {
+          data['acknowledgments'].push(line.substring(17).trim());
+        } else if (line.startsWith('Preferred-Languages: ')) {
+          data['preferred_languages'].push(line.substring(21).trim());
+        } else if (line.startsWith('Canonical: ')) {
+          data['canonical'].push(line.substring(11).trim());
         } else if (line.startsWith('Policy: ')) {
-          data['policy'] = line.substring(8);
+          data['policy'].push(line.substring(8).trim());
+        } else if (line.startsWith('Hiring: ')) {
+          data['hiring'].push(line.substring(8).trim());
+        } else if (line.startsWith('CSAF: ')) {
+          data['csaf'].push(line.substring(6).trim());
+        } else {
+          let [name, value] = line.split(': ');
+          if (name && value) {
+            data['other'].push([name.trim(), value.trim()]);
+          }
         }
-      }
+      }   
+      // Optional
       return data;
     });
   }),

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -131,10 +131,15 @@ return Promise.all([
     let data = {
       status: r.status,
       redirected: r.redirected,
-      url: r.url
+      url: r.url,
+      content_type: r.headers.get("content-type")
     };
 
     return r.text().then(text => {
+      // Abort if final status is not okay (e.g., 404 or 500)
+      if (!r.ok) {
+        return data;
+      }
       data['signed'] = false;
       if (text.startsWith('-----BEGIN PGP SIGNED MESSAGE-----')) {
         data['signed'] = true;

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -188,6 +188,12 @@ return Promise.all([
       }
       // Valid: Required fields exist and only one requirement is not broken. Does not check value content at the moment (e.g., if expires is a valid ISO 8601 date).
       data['valid'] = data['all_required_exist'] && (!data['only_one_requirement_broken'])
+      // Delete empty fields for storage optimization
+      for (let key in data) {
+        if (Array.isArray(data[key]) && data[key].length === 0) {
+          delete data[key];
+        }
+      }
       return data;
     });
   }),


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->
Updated custom metric for https://github.com/HTTPArchive/almanac.httparchive.org/issues/3604

Description of the changes:
Update the parsing of `.well-known/security.txt` to take all new defined fields into account, save undefined/future/custom fields and a basic parsing of whether the file is valid (required fields exist and no field that is only allowed to occur once occurs more than once).

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://example.com/
- https://securitytxt.org/
- https://facebook.com/
- https://slack.com
