### PR TITLE
[Cookies Chapter 2024] Adding Privacy Sandbox well-known files

### DIFF
--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -3,7 +3,7 @@
 
 // README! Instructions for adding a new custom metric for the Web Almanac.
 //
-// 1. Refer for instructions for adding a custom metric in almanamc.js.
+// 1. Refer for instructions for adding a custom metric in almanac.js.
 // 2. This file has a special case where a custom metric uses 'fetch' and in that case we need to return a promise that resolves to JSON
 // 3. Test your change by following the instructions at https://github.com/HTTPArchive/almanac.httparchive.org/issues/33#issuecomment-502288773.
 // 4. Submit a PR to update this file.
@@ -83,6 +83,9 @@ return Promise.all([
   // ecommerce
   parseResponse('/.well-known/assetlinks.json'),
   parseResponse('/.well-known/apple-app-site-association'),
+  // privacy sandbox
+  parseResponse('/.well-known/related-website-set.json'), //Related Website Set
+  parseResponse('/.well-known/privacy-sandbox-attestations.json'), //Attestation File
   // privacy
   parseResponse('/.well-known/gpc.json', r => {
     return r.text().then(text => {


### PR DESCRIPTION
This pull request modifies the `well-known.js` custom metric to parse 2 well-known files related to Google's Privacy Sandbox:

- [related-website-set.json](https://github.com/GoogleChrome/related-website-sets)
- [privacy-sandbox-attestations.json](https://github.com/privacysandbox/attestation)

---

**Test websites**:

- https://mercadolibre.com
- https://www.media.net
- https://yu.ru