### PR TITLE
Log custom metrics for webalmanac

### DIFF
--- a/.github/workflows/wpt-test.yml
+++ b/.github/workflows/wpt-test.yml
@@ -25,10 +25,7 @@ jobs:
           npm install jest
 
       - name: Run WebPageTest with unit tests
-        run: |
-          echo "::group::Unit tests"
-          npm test
-          echo "::endgroup::"
+        run: npm test
         env:
           WPT_SERVER: "webpagetest.httparchive.org"
           WPT_API_KEY: ${{ secrets.HA_API_KEY }}

--- a/.github/workflows/wpt-test.yml
+++ b/.github/workflows/wpt-test.yml
@@ -71,7 +71,7 @@ jobs:
             # Run WebPageTest for each URL
             for TEST_WEBSITE in "${URLS[@]}"; do
               echo "::group::Custom metrics for $TEST_WEBSITE"
-              node tests/wpt.js "$TEST_WEBSITE" "$METRICS"
+              node tests/wpt.js "$TEST_WEBSITE"
               echo "::endgroup::"
             done
           else

--- a/.github/workflows/wpt-test.yml
+++ b/.github/workflows/wpt-test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Run WebPageTest with unit tests
         run: |
           echo "::group::Unit tests"
-            npm test
+          npm test
           echo "::endgroup::"
         env:
           WPT_SERVER: "webpagetest.httparchive.org"
@@ -35,10 +35,6 @@ jobs:
 
       - name: Run WebPageTest for more websites
         run: |
-          # Get the list of files that changed in the PR
-          METRICS=$(git diff --name-only --diff-filter=ACMRT origin/main | \
-            grep -E "^dist/.*\.js$" | xargs -I {} basename {} | cut -d. -f1 | sort | uniq)
-
           # Get the PR body
           PR_BODY="$(cat <<'EOF'
           ${{ github.event.pull_request.body }}

--- a/dist/privacy.js
+++ b/dist/privacy.js
@@ -367,38 +367,38 @@ return JSON.stringify({
       'shadingLanguageVersion',
       'WEBGL_debug_renderer_info',
       'getShaderPrecisionFormat'
-  ].map(api => api.toLowerCase())
+    ].map(api => api.toLowerCase())
 
-  const response_bodies = $WPT_BODIES.filter(body => (body.response_body && (body.type === 'Document' || body.type === 'Script')))
+    const response_bodies = $WPT_BODIES.filter(body => (body.response_body && (body.type === 'Document' || body.type === 'Script')))
 
-  let fingerprintingUsageCounts = {}
-  let likelyFingerprintingScripts = []
+    let fingerprintingUsageCounts = {}
+    let likelyFingerprintingScripts = []
 
-  response_bodies.forEach(req => {
-    let total_occurrences = 0
+    response_bodies.forEach(req => {
+      let total_occurrences = 0
 
-    let body = req.response_body.toLowerCase()
+      let body = req.response_body.toLowerCase()
 
-    fingerprintingAPIs.forEach(api => {
-      let api_occurrences = 0
-      let index = body.indexOf(api)
-      while (index !== -1) {
-        api_occurrences++
-        index = body.indexOf(api, index + 1)
+      fingerprintingAPIs.forEach(api => {
+        let api_occurrences = 0
+        let index = body.indexOf(api)
+        while (index !== -1) {
+          api_occurrences++
+          index = body.indexOf(api, index + 1)
+        }
+
+        if (api_occurrences > 0) {
+          fingerprintingUsageCounts[api] = (fingerprintingUsageCounts[api] || 0) + api_occurrences
+        }
+        total_occurrences += api_occurrences
+      })
+
+      if (total_occurrences >= 5) { //TODO what should this threshold be?
+        likelyFingerprintingScripts.push(req.url)
       }
-
-      if (api_occurrences > 0) {
-        fingerprintingUsageCounts[api] = (fingerprintingUsageCounts[api] || 0) + api_occurrences
-      }
-      total_occurrences += api_occurrences
     })
 
-    if (total_occurrences >= 5) { //TODO what should this threshold be?
-      likelyFingerprintingScripts.push(req.url)
-    }
-  })
-
-  return {counts: fingerprintingUsageCounts, likelyFingerprintingScripts}
+    return { counts: fingerprintingUsageCounts, likelyFingerprintingScripts }
   })(),
 
   /**
@@ -419,7 +419,7 @@ return JSON.stringify({
             results[dns_hostname] = dns_info.results.canonical_names;
           }
         }
-      } catch {}
+      } catch { }
     }
 
     return results;

--- a/tests/unit-tests.test.js
+++ b/tests/unit-tests.test.js
@@ -8,6 +8,7 @@ beforeAll(async () => {
 }, 400000);
 
 test('_ads parsing', () => {
+  assert.ok(wpt_data["_ads"])
   assert.ok(wpt_data["_ads"].ads);
   assert.ok(wpt_data["_ads"].app_ads);
   assert.ok(wpt_data["_ads"].sellers);

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -34,6 +34,8 @@ function getChangedCustomMetrics() {
       return;
     }
 
+    console.log(stdout)
+
     metricsList = stdout.split('\n')
       .filter(file => /^dist\/.*\.js$/.test(file))
       .map(file => file.split('/').pop().split('.').slice(0, -1).join('.'))

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -102,7 +102,7 @@ function runWPTTest(url) {
 if (is_direct_run) {
   const url = argv[2];
 
-  runWPTTest(url, metrics_to_log);
+  runWPTTest(url);
 }
 
 module.exports = { runWPTTest };

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -28,10 +28,8 @@ function getCustomMetrics() {
  *
  * @returns {string[]} An array of the base names of the JavaScript files without the '.js' extension.
  */
-function getChangedCustomMetrics() {
-  let metricsList = []
-
-  exec('git diff --name-only --diff-filter=ACMRT origin/main', (error, stdout, stderr) => {
+async function getChangedCustomMetrics() {
+  const metricsList = await exec('git diff --name-only --diff-filter=ACMRT origin/main', (error, stdout, stderr) => {
     if (error) {
       console.error(`Error executing git command: ${error}`);
       return;
@@ -46,7 +44,10 @@ function getChangedCustomMetrics() {
       .map(file => path.basename(file, '.js'))
 
     metricsList = Array.from(new Set(metricsList)).sort()
+
+    return metricsList;
   });
+
   console.log(metricsList)
 
   return metricsList;

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -29,7 +29,7 @@ function getCustomMetrics() {
  * @returns {string[]} An array of the base names of the JavaScript files without the '.js' extension.
  */
 function getChangedCustomMetrics() {
-  let metricsList
+  let metricsList = []
 
   exec('git diff --name-only --diff-filter=ACMRT origin/main', (error, stdout, stderr) => {
     if (error) {

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -54,8 +54,10 @@ function getChangedCustomMetrics() {
  * @throws {Error} If the test run fails or the response status code is not 200.
  */
 function runWPTTest(url) {
-  const custom_metrics = getCustomMetrics();
-  const metrics_to_log = getChangedCustomMetrics();
+  const custom_metrics = getCustomMetrics()
+  console.log('CUSTOM METRICS:', custom_metrics.join(' '))
+  const metrics_to_log = getChangedCustomMetrics()
+  console.log('METRICS TO LOG:', metrics_to_log.join(' '))
 
   let options = { key: wptApiKey, custom: '' };
   for (const metric_name of custom_metrics) {
@@ -75,6 +77,7 @@ function runWPTTest(url) {
         let wpt_custom_metrics = {}
         let wpt_custom_metrics_to_log = {}
         for (const metric_name of custom_metrics) {
+          console.log(`Retrieving custom metric ${metric_name}`)
           wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
             wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric);

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -73,10 +73,14 @@ function runWPTTest(url) {
       } else {
         console.log(`WPT test run for ${url} completed`);
         let wpt_custom_metrics = {}
-        for (const metric_name of metrics_to_log) {
+        let wpt_custom_metrics_to_log = {}
+        for (const metric_name of custom_metrics) {
           wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
             wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
+            if(metric_name in metrics_to_log) {
+              wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
+            }
           } catch (e) {
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
@@ -86,7 +90,7 @@ function runWPTTest(url) {
           `<summary><strong>Custom metrics for ${url}</strong></summary>\n\n` +
           `WPT test run results: ${response.data.summary}\n` +
           (is_direct_run ? 'Changed custom metrics values:\n' +
-            `\`\`\`json\n${JSON.stringify(wpt_custom_metrics, null, 4)}\n\`\`\`\n` : '') +
+            `\`\`\`json\n${JSON.stringify(wpt_custom_metrics_to_log, null, 4)}\n\`\`\`\n` : '') +
           '</details>\n');
 
         resolve(wpt_custom_metrics);

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -89,17 +89,21 @@ function runWPTTest(url) {
             if (metric_name in metrics_to_log) {
               wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
             }
+            console.log(`Custom metric ${metric_name}:`, JSON.stringify(wpt_custom_metrics[`_${metric_name}`]));
+            console.log(`Custom metrics to log:`, JSON.stringify(wpt_custom_metrics_to_log))
           } catch (e) {
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
         }
 
-        fs.appendFileSync('test-results.md', '<details>\n' +
-          `<summary><strong>Custom metrics for ${url}</strong></summary>\n\n` +
-          `WPT test run results: ${response.data.summary}\n` +
-          (is_direct_run ? 'Changed custom metrics values:\n' +
-            `\`\`\`json\n${JSON.stringify(wpt_custom_metrics_to_log, null, 4)}\n\`\`\`\n` : '') +
-          '</details>\n');
+        fs.appendFileSync('test-results.md', `<details>
+          <summary><strong>Custom metrics for ${url}</strong></summary>
+          WPT test run results: ${response.data.summary}
+          Changed custom metrics values:
+            \`\`\`json
+            ${JSON.stringify(wpt_custom_metrics_to_log, null, 4)}
+            \`\`\`
+          </details>\n`);
 
         resolve(wpt_custom_metrics);
       }

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -69,15 +69,15 @@ function runWPTTest(url) {
         console.log(`WPT test run for ${url} completed`);
         let wpt_custom_metrics = {}
         let wpt_custom_metrics_to_log = {}
+
         for (const metric_name of custom_metrics) {
           wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
             wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
-            if (metric_name in metrics_to_log) {
+            if (metrics_to_log.includes(metric_name)) {
               wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
             }
-            console.log(`Custom metric ${metric_name}:`, JSON.stringify(wpt_custom_metrics[`_${metric_name}`]));
-            console.log(`Custom metrics to log:`, JSON.stringify(wpt_custom_metrics_to_log))
+
           } catch (e) {
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
@@ -88,9 +88,9 @@ function runWPTTest(url) {
 
 WPT test run results: ${response.data.summary}
 Changed custom metrics values:
-\```json
+\`\`\`json
 ${JSON.stringify(wpt_custom_metrics_to_log, null, 4)}
-\```
+\`\`\`
 </details>\n\n`);
 
         resolve(wpt_custom_metrics);

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -45,11 +45,9 @@ function getChangedCustomMetrics() {
       .filter(file => RegExp('^dist\/.*\.js$', 'g').test(file))
       .map(file => path.basename(file, '.js'))
 
-    console.log(metricsList)
-
     metricsList = Array.from(new Set(metricsList)).sort()
-
   });
+  console.log(metricsList)
 
   return metricsList;
 }

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -78,7 +78,7 @@ function runWPTTest(url) {
           wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
             wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
-            if(metric_name in metrics_to_log) {
+            if (metric_name in metrics_to_log) {
               wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
             }
           } catch (e) {

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -29,24 +29,24 @@ function getCustomMetrics() {
  * @returns {string[]} An array of the base names of the JavaScript files without the '.js' extension.
  */
 async function getChangedCustomMetrics() {
-  const metricsList = await exec('git diff --name-only --diff-filter=ACMRT origin/main', (error, stdout, stderr) => {
-    if (error) {
-      console.error(`Error executing git command: ${error}`);
-      return;
-    }
-    if (stderr) {
-      console.error(`Git stderr: ${stderr}`);
-      return;
-    }
+  const {error, stdout, stderr} = await exec('git diff --name-only --diff-filter=ACMRT origin/main')
 
-    metricsList = stdout.split('\n')
-      .filter(file => RegExp('^dist\/.*\.js$', 'g').test(file))
-      .map(file => path.basename(file, '.js'))
+  if (error) {
+    console.error(`Error executing git command: ${error}`);
+    return;
+  }
+  if (stderr) {
+    console.error(`Git stderr: ${stderr}`);
+    return;
+  }
 
-    metricsList = Array.from(new Set(metricsList)).sort()
+  console.log(stdout);
 
-    return metricsList;
-  });
+  metricsList = stdout.split('\n')
+    .filter(file => RegExp('^dist\/.*\.js$', 'g').test(file))
+    .map(file => path.basename(file, '.js'))
+
+  metricsList = Array.from(new Set(metricsList)).sort()
 
   console.log(metricsList)
 


### PR DESCRIPTION
Now you can see custom metric logged by default from running unit tests with Web Almanac.

Applied formatting to `privacy.js` to trigger the 'changed custom metric' test.

---
**Test websites**:

- https://example.com/
