### PR TITLE
fix imagesrcset bug

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -264,7 +264,7 @@ function getLcpPreloadInfo(rawDoc, lcpUrl) {
 
         let src = link.href;
         if (link.hasAttribute('imagesrcset')) {
-            src = splitSrcSet(link.imagesrcset).find(src => src == lcpUrl);
+            src = splitSrcSet(link.imagesrcset || link.getAttribute('imagesrcset')).find(src => src == lcpUrl);
         }
 
         return src == lcpUrl;

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -264,7 +264,7 @@ function getLcpPreloadInfo(rawDoc, lcpUrl) {
 
         let src = link.href;
         if (link.hasAttribute('imagesrcset')) {
-            src = splitSrcSet(link.imagesrcset || link.getAttribute('imagesrcset'))?.find(src => src == lcpUrl);
+            src = splitSrcSet(link.getAttribute('imagesrcset'))?.find(src => src == lcpUrl);
         }
 
         return src == lcpUrl;

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -264,7 +264,7 @@ function getLcpPreloadInfo(rawDoc, lcpUrl) {
 
         let src = link.href;
         if (link.hasAttribute('imagesrcset')) {
-            src = splitSrcSet(link.imagesrcset || link.getAttribute('imagesrcset')).find(src => src == lcpUrl);
+            src = splitSrcSet(link.imagesrcset || link.getAttribute('imagesrcset'))?.find(src => src == lcpUrl);
         }
 
         return src == lcpUrl;


### PR DESCRIPTION
28% of Angular 17 apps using the image directive have been missing performance data due to errors. Looking into it, it seems that `link.imagesrcset` is undefined in some of these cases. Grabbing the attribute instead of the prop with `link.getAttribute` fixes the issue.

See example failure: https://www.webpagetest.org/result/240618_AiDc8Y_E9D/3/details/
See example fix: https://www.webpagetest.org/result/240618_AiDcZ3_E78/2/details/

---
**Test websites**:

- https://exploreti.com/


