### PR TITLE
Fix performance custom metrics

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -371,3 +371,4 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
 }).catch(error => {
     return {error};
 });
+

--- a/dist/performance.js
+++ b/dist/performance.js
@@ -371,4 +371,3 @@ return Promise.all([getLcpElement()]).then(([lcp_elem_stats]) => {
 }).catch(error => {
     return {error};
 });
-

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -73,9 +73,9 @@ function runWPTTest(url) {
         for (const metric_name of custom_metrics) {
           wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
-            wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
+            wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric.toString());
             if (metrics_to_log.includes(metric_name)) {
-              wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
+              wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric.toString());
             }
 
           } catch (e) {

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -79,7 +79,7 @@ function runWPTTest(url) {
             }
 
           } catch (e) {
-            console.log('JSON.parse failed', e);
+            console.log(`JSON.parse of metric ${metric_name} failed:`, e);
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
         }

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -71,15 +71,22 @@ function runWPTTest(url) {
         let wpt_custom_metrics_to_log = {}
 
         for (const metric_name of custom_metrics) {
-          wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
+          let wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
-            wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric.toString());
+            // Some custom metrics are returned as objects, some as strings
+            if (typeof wpt_custom_metric === 'string') {
+              wpt_custom_metric = JSON.parse(wpt_custom_metric);
+            }
+            wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
+
             if (metrics_to_log.includes(metric_name)) {
-              wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric.toString());
+              wpt_custom_metrics_to_log[`_${metric_name}`] = wpt_custom_metric;
             }
 
           } catch (e) {
-            console.log(`JSON.parse of metric ${metric_name} failed:`, e, wpt_custom_metric);
+            console.log(`JSON.parse of metric ${metric_name} failed:`);
+            console.log(e);
+            console.log(wpt_custom_metric);
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
         }

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -73,16 +73,23 @@ function runWPTTest(url) {
         for (const metric_name of custom_metrics) {
           let wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
-            // Try to parse strings into JSON to allow them to be pretty printed
-            // Not all custom metrics are JSON strings so this might fail
+            // Some, but not all, custom metrics wrap their return values in JSON.stringify()
+            // Some just return the objects. And some have strings which are not JSON!
+            // Gotta love the consistency!!!
+            //
+            // IMHO wrapping the return in JSON.stringify() is best practice, since WebPageTest
+            // will do that to save to database and you can run into weird edge cases where it
+            // doesn't return data when doing that, so explicitly doing that avoids that when
+            // testing in the console* , but we live in an inconsistent world!
+            // (* see https://github.com/HTTPArchive/custom-metrics/pull/113#issuecomment-2043937823)
+            //
+            // Anyway, if it's a string, see if we can parse it back to a JS object to pretty
+            // print it, but be prepared for that to fail for non-JSON strings so wrap in try/catch
             if (typeof wpt_custom_metric === 'string') {
-              console.log(`JSON.parse worked for ${metric_name}`);
-              console.log(`${wpt_custom_metric}`);
               wpt_custom_metric = JSON.parse(wpt_custom_metric);
-              console.log(`${wpt_custom_metric}`);
             }
           } catch (e) {
-            // If it fails, that's OK as we'll just stick with the exact output
+            // If it fails, that's OK as we'll just stick with the exact string output anyway
           }
           wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           if (metrics_to_log.includes(metric_name)) {

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -79,7 +79,7 @@ function runWPTTest(url) {
             }
 
           } catch (e) {
-            console.log(`JSON.parse of metric ${metric_name} failed:`, e);
+            console.log(`JSON.parse of metric ${metric_name} failed:`, e, wpt_custom_metric);
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
         }

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -73,18 +73,13 @@ function runWPTTest(url) {
         for (const metric_name of custom_metrics) {
           let wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
-            // Some custom metrics are returned as objects,
-            // some as strings that can be parsed into objects
-            // And some as plain old strings.
-            // Try to parse strings
-            // if (typeof wpt_custom_metric === 'string') {
-            wpt_custom_metric = JSON.parse(wpt_custom_metric);
-            // }
-
+            // Try to parse strings into JSON to allow them to be pretty printed
+            // Not all custom metrics are JSON strings so this might fail
+            if (typeof wpt_custom_metric === 'string') {
+              wpt_custom_metric = JSON.parse(wpt_custom_metric);
+            }
           } catch (e) {
-            console.log(`JSON.parse of metric ${metric_name} failed:`);
-            console.log(e);
-            console.log(wpt_custom_metric);
+            // If it fails, that's OK as we'll just stick with the exact output
           }
           wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           if (metrics_to_log.includes(metric_name)) {

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -73,21 +73,22 @@ function runWPTTest(url) {
         for (const metric_name of custom_metrics) {
           let wpt_custom_metric = response.data.runs['1'].firstView[`_${metric_name}`];
           try {
-            // Some custom metrics are returned as objects, some as strings
-            if (typeof wpt_custom_metric === 'string') {
-              wpt_custom_metric = JSON.parse(wpt_custom_metric);
-            }
-            wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
-
-            if (metrics_to_log.includes(metric_name)) {
-              wpt_custom_metrics_to_log[`_${metric_name}`] = wpt_custom_metric;
-            }
+            // Some custom metrics are returned as objects,
+            // some as strings that can be parsed into objects
+            // And some as plain old strings.
+            // Try to parse strings
+            // if (typeof wpt_custom_metric === 'string') {
+            wpt_custom_metric = JSON.parse(wpt_custom_metric);
+            // }
 
           } catch (e) {
             console.log(`JSON.parse of metric ${metric_name} failed:`);
             console.log(e);
             console.log(wpt_custom_metric);
-            wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
+          }
+          wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
+          if (metrics_to_log.includes(metric_name)) {
+            wpt_custom_metrics_to_log[`_${metric_name}`] = wpt_custom_metric;
           }
         }
 

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -76,7 +76,10 @@ function runWPTTest(url) {
             // Try to parse strings into JSON to allow them to be pretty printed
             // Not all custom metrics are JSON strings so this might fail
             if (typeof wpt_custom_metric === 'string') {
+              console.log(`JSON.parse worked for ${metric_name}`);
+              console.log(`${wpt_custom_metric}`);
               wpt_custom_metric = JSON.parse(wpt_custom_metric);
+              console.log(`${wpt_custom_metric}`);
             }
           } catch (e) {
             // If it fails, that's OK as we'll just stick with the exact output

--- a/tests/wpt.js
+++ b/tests/wpt.js
@@ -79,6 +79,7 @@ function runWPTTest(url) {
             }
 
           } catch (e) {
+            console.log('JSON.parse failed', e);
             wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
           }
         }


### PR DESCRIPTION
Noticed performance custom metrics were not getting logged in our CI tests.

This was because the current logic was as follows:

```js
          try {
            wpt_custom_metrics[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
            if (metrics_to_log.includes(metric_name)) {
              wpt_custom_metrics_to_log[`_${metric_name}`] = JSON.parse(wpt_custom_metric);
            }

          } catch (e) {
            wpt_custom_metrics[`_${metric_name}`] = wpt_custom_metric;
          }
```

That says only log metrics we're interested in if `JSON.parse` succeeds.

However, many metrics are returned as Objects rather than JSON and so `JSON.parse` fails (as it doesn't need to be parsed as it'a already an object!), and others aren't valid JSON as just plain strings. In both cases the `if (metrics_to_log.includes(metric_name)) {` part isn't called and they are excluded from the output.

This PR refactors to move code out of the `try` to log in both cases.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://example.com/
- https://exploreti.com/
