### PR TITLE
Add two custom metrics for video using source elements with media queries

### DIFF
--- a/dist/media.js
+++ b/dist/media.js
@@ -127,7 +127,7 @@ return JSON.stringify({
     'video_using_source_media_count': document.querySelectorAll('video:has(source[media])').length,
     //Returns the media attribute values in use on video source elements
     'video_source_media_values': Array.from(document.querySelectorAll('video source[media]')).map(source => {
-        return source.getAttribute('media')
+        return source.getAttribute('media');
     }),
     //returns an array of the number of source files per video tag.
     'video_source_format_count': Array.from(document.querySelectorAll('video')).map(video => video.querySelectorAll('source').length),

--- a/dist/media.js
+++ b/dist/media.js
@@ -123,6 +123,12 @@ return JSON.stringify({
     'video_display_style' : Array.from(document.querySelectorAll('video')).map(video => {
       return getComputedStyle(video, null).getPropertyValue('display');
     }),
+    //Returns the number of video elements that contain a source element that uses a media attribute
+    'video_using_source_media_count': document.querySelectorAll('video:has(source[media])').length,
+    //Returns the media attribute values in use on video source elements
+    'video_source_media_values': Array.from(document.querySelectorAll('video source[media]')).map(source => {
+        return source.getAttribute('media')
+    }),
     //returns an array of the number of source files per video tag.
     'video_source_format_count': Array.from(document.querySelectorAll('video')).map(video => video.querySelectorAll('source').length),
     //Returns all of the video types for each source file


### PR DESCRIPTION
The first metric returns the number of video elements that have a source element using media. The second is an array of all video source media attribute values in play.

These metrics are meant to keep track of responsive video usage now that the features are standard and supported again.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://scottjehl.com/posts/using-responsive-video/
- https://scottjehl.com/sandbox/video-media/