### PR TITLE
Limit responsive image URLs

### DIFF
--- a/dist/responsive_images.js
+++ b/dist/responsive_images.js
@@ -305,10 +305,10 @@ function intrinsicOrExtrinsicSizing( computedStyles ) {
 function getImgData( img ) {
 
   const imgData = imgFeatures( img );
-  // Limit URLs to 200 chars so data URLs don't take up huge amounts of space.
+  // Limit data URLs so they don't take up huge amounts of space.
   imgData.url =
-    (img.currentSrc || img.src).length > 200 ?
-    (img.currentSrc || img.src).slice(0, 199) + '…' :
+    (img.currentSrc || img.src)?.startsWith('data:') && (img.currentSrc || img.src)?.length > 50 ?
+    (img.currentSrc || img.src)?.slice(0, 50) + '…' :
     (img.currentSrc || img.src);
   imgData.totalCandidates = totalNumberOfCandidates( img );
 
@@ -362,8 +362,10 @@ function getImgData( img ) {
           !isFromSource &&
           !( imgData.srcsetHasWDescriptors ) ) {
       srcsetCandidates.push( {
-        // Limit URLs to 200 chars so data URLs don't take up huge amounts of space.
-        url: img.getAttribute( 'src' ).length > 200 ? img.getAttribute( 'src' ).slice(0, 199) + '…' : img.getAttribute( 'src' )
+        // Limit data URLs so they don't take up huge amounts of space.
+        url: img.getAttribute( 'src' )?.startsWith('data:') && img.getAttribute( 'src' )?.length > 50 ?
+          img.getAttribute( 'src' )?.slice(0, 50) + '…' :
+          img.getAttribute( 'src' )
       } )
     }
 

--- a/dist/responsive_images.js
+++ b/dist/responsive_images.js
@@ -305,7 +305,11 @@ function intrinsicOrExtrinsicSizing( computedStyles ) {
 function getImgData( img ) {
 
   const imgData = imgFeatures( img );
-  imgData.url = img.currentSrc || img.src;
+  // Limit URLs to 200 chars so data URLs don't take up huge amounts of space.
+  imgData.url =
+    (img.currentSrc || img.src).length > 200 ?
+    (img.currentSrc || img.src).slice(0, 199) + '…' :
+    (img.currentSrc || img.src);
   imgData.totalCandidates = totalNumberOfCandidates( img );
 
   if (imgData.hasHeight) {
@@ -358,7 +362,8 @@ function getImgData( img ) {
           !isFromSource &&
           !( imgData.srcsetHasWDescriptors ) ) {
       srcsetCandidates.push( {
-        url: img.getAttribute( 'src' )
+        // Limit URLs to 200 chars so data URLs don't take up huge amounts of space.
+        url: img.getAttribute( 'src' ).length > 200 ? img.getAttribute( 'src' ).slice(0, 199) + '…' : img.getAttribute( 'src' )
       } )
     }
 


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->
See: https://github.com/HTTPArchive/data-pipeline/issues/262#issuecomment-2348864332

Limit responsive image URLs to prevent massive data urls taking up lots of custom metric space.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://www.pronews.gr/
