### PR TITLE
Resolved issue with is_lcp_statically_discoverable

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -306,7 +306,7 @@ function getRawLcpElement(rawDoc, lcpUrl) {
             src = i.getAttribute('href');
         }
 
-        return src == lcpUrl;
+        return new URL(src, location.href).href == lcpUrl;
     });
 
     // lcp_elem_stats will match the img, not the source.


### PR DESCRIPTION
The raw HTML (from response_body) uses relative URLs for images, for example "/static/img/logo.png", while calling .src on a document with a location, gives you absolute URLs, such as https://happymod.com/static/img/logo.png.

Consequently, when checking for the LCP element, we need to wrap the src with new URL to get an absolute URL. 

---
**Test websites**:

- https://happymod.com/
- https://httparchive.org/
