### PR TITLE
Detect WordPress theme slugs

### DIFF
--- a/dist/cms.js
+++ b/dist/cms.js
@@ -13,26 +13,24 @@ function usesBlockTheme() {
  */
 function getWordPressTheme() {
   const theme = {
-    theme: 'unknown',
-    parent_theme: '',
+    theme: '',
+    child_theme: '',
   };
   try {
     const bodyClass = document.body.classList;
 
     const parentTheme = Array.from( bodyClass ).find( c => c.startsWith( 'wp-theme-' ) );
+
+    if ( parentTheme ) {
+      theme.theme = parentTheme.replace( 'wp-theme-', '' );
+    }
+
     const childTheme = Array.from( bodyClass ).find( c => c.startsWith( 'wp-child-theme-' ) );
 
     if ( childTheme ) {
-      theme.theme = childTheme;
-
-      // If there is a child theme, there should always be a parent theme.
-      if ( parentTheme ) {
-        theme.parent_theme = parentTheme;
-      }
-    } else if ( parentTheme ) {
-      // There is no child theme, only a parent theme.
-      theme.theme = parentTheme;
+      theme.child_theme = childTheme.replace( 'wp-child-theme-', '' );
     }
+
   } catch ( e ) {}
   return theme;
 }

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -13,8 +13,8 @@ function usesBlockTheme() {
  */
 function getWordPressTheme() {
   const theme = {
-    theme: '',
-    child_theme: '',
+    theme: null,
+    child_theme: null,
   };
   try {
     const bodyClass = document.body.classList;
@@ -23,6 +23,7 @@ function getWordPressTheme() {
 
     if ( parentTheme ) {
       theme.theme = parentTheme.replace( 'wp-theme-', '' );
+      theme.child_theme = '';
     }
 
     const childTheme = Array.from( bodyClass ).find( c => c.startsWith( 'wp-child-theme-' ) );

--- a/dist/cms.js
+++ b/dist/cms.js
@@ -4,6 +4,39 @@ function usesBlockTheme() {
   return !!document.querySelector('div.wp-site-blocks');
 }
 
+/**
+ * Detects the WordPress parent and child theme slugs.
+ *
+ * See https://core.trac.wordpress.org/changeset/59698.
+ *
+ * @returns {object} Object with fields `theme` and `parent_theme`.
+ */
+function getWordPressTheme() {
+  const theme = {
+    theme: 'unknown',
+    parent_theme: '',
+  };
+  try {
+    const bodyClass = document.body.classList;
+
+    const parentTheme = Array.from( bodyClass ).find( c => c.startsWith( 'wp-theme-' ) );
+    const childTheme = Array.from( bodyClass ).find( c => c.startsWith( 'wp-child-theme-' ) );
+
+    if ( childTheme ) {
+      theme.theme = childTheme;
+
+      // If there is a child theme, there should always be a parent theme.
+      if ( parentTheme ) {
+        theme.parent_theme = parentTheme;
+      }
+    } else if ( parentTheme ) {
+      // There is no child theme, only a parent theme.
+      theme.theme = parentTheme;
+    }
+  } catch ( e ) {}
+  return theme;
+}
+
 // Detects if a WordPress embed block is on the page
 function hasWordPressEmbedBlock() {
   return !!document.querySelector('figure.wp-block-embed');
@@ -195,6 +228,7 @@ function usesInteractivityAPI() {
 }
 
 const wordpress = {
+  theme: getWordPressTheme(),
   block_theme: usesBlockTheme(),
   has_embed_block: hasWordPressEmbedBlock(),
   embed_block_count: getWordPressEmbedBlockCounts(),


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

There is a [new change](https://core.trac.wordpress.org/changeset/59698) in the upcoming WordPress 6.8 release that exposes the slugs of the currently active theme(s) via a class on the `<body>`.

This makes it easy to track individual theme adoption.

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://ma.tt/
