### PR TITLE
Updated feature for Related Website Sets and Apple app site association

### DIFF
--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -99,9 +99,52 @@ return Promise.all([
       };
     });
   }),
-  parseResponse('/.well-known/apple-app-site-association'),
+  // Apple App Site Association
+  parseResponse('/.well-known/apple-app-site-association', r => {
+    return r.text().then(text => {
+      let result = {
+        applinks: null,
+        webcredentials: null,
+        appclips: null
+      };
+
+      try {
+        let data = JSON.parse(text);
+        result.applinks = data.applinks || null;
+        result.webcredentials = data.webcredentials || null;
+        result.appclips = data.appclips || null;
+      } catch (e) {
+        // Failed to parse JSON, result will contain default values.
+      }
+
+      return result;
+    });
+  }),
   // privacy sandbox
-  parseResponse('/.well-known/related-website-set.json'), //Related Website Set
+  parseResponse('/.well-known/related-website-set.json', r => { //Related Website Set
+    return r.text().then(text => {
+      let result = {
+        primary: null,
+        associatedSites: null,
+        serviceSites: null,
+        ccTLDs: null,
+        rationaleBySite: null
+      };
+
+      try {
+        let data = JSON.parse(text);
+        result.primary = data.primary || null;
+        result.associatedSites = data.associatedSites || null;
+        result.serviceSites = data.serviceSites || null;
+        result.ccTLDs = data.ccTLDs || null;
+        result.rationaleBySite = data.rationaleBySite || null;
+      } catch (e) {
+        // Failed to parse JSON, result will contain default values.
+      }
+
+      return result;
+    });
+  }),
   parseResponse('/.well-known/privacy-sandbox-attestations.json'), //Attestation File
   // privacy
   parseResponse('/.well-known/gpc.json', r => {

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -116,7 +116,7 @@ return Promise.all([
       };
     });
   }),
-  // privacy sandbox
+  // Privacy Sandbox
   parseResponse('/.well-known/related-website-set.json', r => {
     return r.text().then(text => {
       let result = {

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -101,43 +101,33 @@ return Promise.all([
   }),
   // Apple App Site Association
   parseResponse('/.well-known/apple-app-site-association', r => {
-    return r.text().then(text => {
-      let result = {
-        applinks: null,
-        webcredentials: null,
-        appclips: null
-      };
-
-      try {
-        let data = JSON.parse(text);
-        result.applinks = data.applinks || null;
-        result.webcredentials = data.webcredentials || null;
-        result.appclips = data.appclips || null;
-      } catch (e) {
-        // Failed to parse JSON, result will contain default values.
+    return r.json().then(data => {
+      let hasAppLinks = false;
+      let hasWebCredentials = false;
+      if (data.applinks) {
+        hasAppLinks = true;
       }
-
-      return result;
+      if (data.webcredentials) {
+        hasWebCredentials = true;
+      }  
+      return {
+        app_links: hasAppLinks,
+        web_credentials: hasWebCredentials
+      };
     });
   }),
   // privacy sandbox
-  parseResponse('/.well-known/related-website-set.json', r => { //Related Website Set
+  parseResponse('/.well-known/related-website-set.json', r => {
     return r.text().then(text => {
       let result = {
         primary: null,
-        associatedSites: null,
-        serviceSites: null,
-        ccTLDs: null,
-        rationaleBySite: null
+        associatedSites: null
       };
 
       try {
         let data = JSON.parse(text);
         result.primary = data.primary || null;
         result.associatedSites = data.associatedSites || null;
-        result.serviceSites = data.serviceSites || null;
-        result.ccTLDs = data.ccTLDs || null;
-        result.rationaleBySite = data.rationaleBySite || null;
       } catch (e) {
         // Failed to parse JSON, result will contain default values.
       }

--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -109,7 +109,7 @@ return Promise.all([
       }
       if (data.webcredentials) {
         hasWebCredentials = true;
-      }  
+      }
       return {
         app_links: hasAppLinks,
         web_credentials: hasWebCredentials


### PR DESCRIPTION
## Enhance Privacy Sandbox Related Website Sets and Apple App Site Association Tracking

This pull request enhances the tracking of Privacy Sandbox Related Website Sets (RWS) features and Apple App Site Association by improving data collection and parsing for:

* **Privacy Sandbox**:
    * **Related Website Sets:** Parses the `/.well-known/related-website-set.json` file to extract detailed information about website relationships, including primary domain, associated sites, service sites, ccTLDs, and rationale.

* **Apple App Site Association:** Parses the `/.well-known/apple-app-site-association` file to detect the presence of `applinks`, `webcredentials`, `activitycontinuation`, and `appclips` services.

**Changes:**

* Updated `parseResponse` function to handle and parse the following files:
    * `/.well-known/related-website-set.json`
    * `/.well-known/apple-app-site-association`

**Rationale:**

* **Privacy Sandbox:**
    * **Related Website Sets:** Collecting detailed information about website relationships provides valuable insights into the usage and adoption of this feature.


* **Apple App Site Association:** Detecting the presence of different services in the `apple-app-site-association` file helps us understand how websites integrate with Apple features like universal links, shared web credentials, and App Clips.




---

**Test websites**:
- https://timesinternet.in/
- https://mercadolibre.com/
- https://on.com/
- https://google.com/
- https://www.google.com/