### PR TITLE
Fix PWA custom metric

### DIFF
--- a/dist/pwa.js
+++ b/dist/pwa.js
@@ -24,7 +24,7 @@ const manifestURLs = new Set(Array.from(document.querySelectorAll('link[rel=mani
 
 const initiatorMap = requests.reduce((map, request) => {
   const url = request.url;
-  let initiator = request.initiator.url;
+  let initiator = request.initiator?.url;
   if (!initiator) {
     initiator = request.initiator?.stack?.callFrames?.[0]?.url
   }


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

Discovered the pwa custom metric isn't working when initiator is blank

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://example.com/
- https://web.dev/
