### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ return {
 
 To test a custom metric, for example [`doctype.js`](https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/doctype.js), you can enter the script directly on [webpagetest.httparchive.org](https://webpagetest.httparchive.org/?debug=1) under "Advanced" -> "Custom" tab.
 
-![image](https://user-images.githubusercontent.com/1120896/59539351-e3ecdd80-8eca-11e9-8b43-76bbd7a12029.png)
+![Custom tab](https://github.com/user-attachments/assets/902c9f0f-89a7-4281-b724-391fbbbe43ca)
+
 
 Note that all WPT custom metrics must have `[metricName]` at the start of the script. This is excluded in the HTTP Archive code and generated automatically based on the file name, so you will need to manually ensure that it's set.
 
@@ -69,9 +70,9 @@ The log ouput can be found in the main results page to the left of the waterfall
 
 To see the custom metric results, select a run, first click on "Details", and then on the "Custom Metrics" link in the top right corner:
 
-![image](https://user-images.githubusercontent.com/1120896/88727164-0e185380-d0fd-11ea-973e-81a50cd24013.png)
+![Details results](https://github.com/user-attachments/assets/eaa39b6c-1aa9-43f7-a910-a9eebd1f0a47)
 
-![image](https://user-images.githubusercontent.com/1120896/88727208-24beaa80-d0fd-11ea-8ae1-57df2c8505e4.png)
+![Custom metrics](https://github.com/user-attachments/assets/21eba08c-f758-481c-a01a-03477a4b4fd1)
 
 For complex metrics like [almanac.js](./dist/almanac.js) you can more easily explore the results by copy/pasting the JSON into your browser console.
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ return {
 
 ### Manual testing using webpagetest.org website
 
-To test a custom metric, for example [`doctype.js`](https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/doctype.js), you can enter the script directly on [webpagetest.org](https://webpagetest.org?debug=1) under the "Custom" tab.
+To test a custom metric, for example [`doctype.js`](https://github.com/HTTPArchive/legacy.httparchive.org/blob/master/custom_metrics/doctype.js), you can enter the script directly on [webpagetest.httparchive.org](https://webpagetest.httparchive.org/?debug=1) under "Advanced" -> "Custom" tab.
 
 ![image](https://user-images.githubusercontent.com/1120896/59539351-e3ecdd80-8eca-11e9-8b43-76bbd7a12029.png)
 
 Note that all WPT custom metrics must have `[metricName]` at the start of the script. This is excluded in the HTTP Archive code and generated automatically based on the file name, so you will need to manually ensure that it's set.
 
-If you include the `debug=1` parameter on the WPT home page, for example [https://webpagetest.org?debug=1](https://webpagetest.org?debug=1), the test results will include a raw debug log from the agent including the devtools commands to run the custom metrics (and any handled exceptions).
+If you include the `debug=1` parameter on the WPT home page, for example [https://webpagetest.httparchive.org?debug=1](https://webpagetest.httparchive.org?debug=1), the test results will include a raw debug log from the agent including the devtools commands to run the custom metrics (and any handled exceptions).
 The log ouput can be found in the main results page to the left of the waterfall. For each run there will be a link for the "debug log" (next to the timeline and trace links).
 
 To see the custom metric results, select a run, first click on "Details", and then on the "Custom Metrics" link in the top right corner:
@@ -77,7 +77,7 @@ For complex metrics like [almanac.js](./dist/almanac.js) you can more easily exp
 
 ### Automated WPT test runs
 
-1. WPT tests are running using [WPT API wrapper](https://github.com/webpagetest/webpagetest-api).
+1. WPT tests are running using [WPT API wrapper](https://github.com/HTTPArchive/WebPageTest.api-nodejs).
 2. Test runs are using a private WPT instance, set by the `WPT_HOST` environment variable.
 3. By default, WebAlmanac website is used for testing in every PR.
 4. PR author can define a list of websites to test additionally, by using a markdown list as shown in [PR template](https://github.com/HTTPArchive/custom-metrics/blob/main/.github/PULL_REQUEST_TEMPLATE/custom_metrics_pr_template.md).


### PR DESCRIPTION
Updated readme to represent an actual HTTP Archive workflow. Also webpagetest.org website has different UI.

- [x] Updated URLs in the "Manual testing using webpagetest.org website" section to use `webpagetest.httparchive.org` instead of `webpagetest.org`.

- [x] Updated the link to the WPT API wrapper in the "Automated WPT test runs" section to point to the correct repository at `HTTPArchive/WebPageTest.api-nodejs`.