### PR TITLE
Add error checking on performance custom metric

### DIFF
--- a/dist/performance.js
+++ b/dist/performance.js
@@ -325,6 +325,7 @@ function getLcpResponseObject(lcpUrl) {
 }
 
 function getParameterCaseInsensitive(object, key) {
+  if (!object || !key) return;
   return object[Object.keys(object).find(k => k.toLowerCase() === key.toLowerCase())];
 }
 


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

Speculation Rules custom metric is causing the performance custom metric to fail with error sometimes with:

```json
{"errorMessage":"Cannot convert undefined or null to object","errorName":"TypeError"}
```

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://example.com/
- https://www.swp.de/lokales/horb/tanklaster-mit-loesungsmittel-brennt-400-einsatzkraefte-17-stunden-so-lief-der-grosseinsatz-auf-der-a-81-78186666.html
