### PR TITLE
Update agent-card.json for A2A Protocol

### DIFF
--- a/dist/well-known.js
+++ b/dist/well-known.js
@@ -311,6 +311,29 @@ return Promise.all([
       url: r.url
     });
   }),
+  // A2A Agent Card (required + strongly recommended fields)
+  parseResponse('/.well-known/agent-card.json', r => {
+    return r.text().then(text => {
+      let result = {
+        url: null,
+        preferredTransport: null,
+        protocolVersion: null,
+        name: null,
+        description: null
+      };
+      try {
+        let data = JSON.parse(text);
+        result.url = data.url || null;
+        result.preferredTransport = data.preferredTransport || null;
+        result.protocolVersion = data.protocolVersion || null;
+        result.name = data.name || null;
+        result.description = data.description || null;
+      } catch (e) {
+        // Failed to parse JSON
+      }
+      return result;
+    });
+  }),
   parseResponseWithRedirects('/.well-known/resource-that-should-not-exist-whose-status-code-should-not-be-200/', r => {
     return Promise.resolve({
       status: r.status,


### PR DESCRIPTION
<!-- Add any related issues and a description of the changes proposed in the pull request. -->

## Description

This PR adds support for tracking and analyzing a critical file related to AI Agent discovery and communication:

1.  **Agent Card**: `/.well-known/agent-card.json`

This file is central to the **[Agent2Agent (A2A) Protocol](https://a2a-protocol.org/latest/)** and serves as the agent's digital business card. It's used by clients to discover the agent's identity, capabilities, service endpoints, and security requirements. The changes ensure this file is fetched, parsed, and included in the HTTP Archive's custom metrics for analysis of emerging AI agent standards adoption.

## Changes

1.  Added a new `parseResponse` call for `/.well-known/agent-card.json` to track its presence, structure, and key metadata (e.g., agent name, version, and declared skills).

## Example Output

### Agent Card (`/.well-known/agent-card.json`)
```json
{
  "/.well-known/agent-card.json": {
    "found": true,
    "data": {
      "url": "https://agent.example.com/a2a",
      "preferredTransport": "http",
      "protocolVersion": "0.3.0",
      "name": "Example Service Agent",
      "description": "An agent that provides example services via A2A."
    }
  }
}
```

---
<!-- List the pages that should be automatically tested as part of your custom metric changes. -->
**Test websites**:

- https://www.google.com/
- https://www.mozilla.org/
- https://www.microsoft.com/
- https://www.cloudflare.com/
- https://www.github.com/
